### PR TITLE
Code generation improvements

### DIFF
--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
@@ -10,20 +10,20 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
     protected override Type RecordCollectionType => typeof(IReadOnlyCollection<>);
     protected override Type RecordConcreteCollectionType => typeof(ReadOnlyValueCollection<>);
     protected override string FileNameSuffix => ".template.generated";
-    protected override string RootNamespace => "ExpressionFramework.Domain";
+    protected static string ProjectName => "ExpressionFramework";
+    protected override string RootNamespace => $"{ProjectName}.Domain";
+    protected static string CodeGenerationRootNamespace => $"{ProjectName}.CodeGeneration";
     protected override Type BuilderClassCollectionType => typeof(IEnumerable<>);
     protected override bool AddBackingFieldsForCollectionProperties => true;
     protected override bool AddPrivateSetters => true;
 
-    private static string CodeGenerationRootNamespace => "ExpressionFramework.CodeGeneration";
-
     protected override string GetFullBasePath()
-        => Directory.GetCurrentDirectory().EndsWith("ExpressionFramework")
+        => Directory.GetCurrentDirectory().EndsWith(ProjectName)
             ? System.IO.Path.Combine(Directory.GetCurrentDirectory(), @"src/")
             : System.IO.Path.Combine(Directory.GetCurrentDirectory(), @"../../../../");
 
     protected override string[] GetCustomBuilderTypes()
-        => GetCustomDefaultValueForBuilderClassConstructorValues().Select(x => x.Key.Split('.').Last()).ToArray();
+        => GetAbstractModels().Select(x => x.GetEntityClassName() ).ToArray();
 
     protected override Dictionary<string, string> GetCustomDefaultValueForBuilderClassConstructorValues()
         => new(GetAbstractModels().Select(x => new KeyValuePair<string, string>($"{RootNamespace}.{x.GetEntityClassName()}", "null")));
@@ -45,25 +45,25 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
     );
 
     protected override string[] GetNonDomainTypes()
-        => typeof(ExpressionFrameworkCSharpClassBase).Assembly.GetExportedTypes()
+        => GetType().Assembly.GetExportedTypes()
             .Where(x => x.IsInterface && x.Namespace == CodeGenerationRootNamespace)
             .Select(x => $"{RootNamespace}.{x.Name}")
             .ToArray();
 
     protected ITypeBase[] GetCoreModels()
         => MapCodeGenerationModelsToDomain(
-            typeof(ExpressionFrameworkCSharpClassBase).Assembly.GetExportedTypes()
+            GetType().Assembly.GetExportedTypes()
                 .Where(x => x.IsInterface && x.Namespace == $"{CodeGenerationRootNamespace}.Models" && !GetCustomBuilderTypes().Contains(x.GetEntityClassName())));
 
     protected ITypeBase[] GetAbstractModels()
         => MapCodeGenerationModelsToDomain(
-            typeof(ExpressionFrameworkCSharpClassBase).Assembly.GetExportedTypes()
+            GetType().Assembly.GetExportedTypes()
                 .Where(x => x.IsInterface && x.GetInterfaces().Length == 1)
                 .Select(x => x.GetInterfaces()[0])
                 .Distinct());
 
     protected ITypeBase[] GetOverrideModels(Type abstractType)
         => MapCodeGenerationModelsToDomain(
-            typeof(ExpressionFrameworkCSharpClassBase).Assembly.GetExportedTypes()
+            GetType().Assembly.GetExportedTypes()
                 .Where(x => x.IsInterface && x.GetInterfaces().FirstOrDefault() == abstractType));
 }

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
@@ -10,60 +10,8 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
     protected override Type RecordCollectionType => typeof(IReadOnlyCollection<>);
     protected override Type RecordConcreteCollectionType => typeof(ReadOnlyValueCollection<>);
     protected override string FileNameSuffix => ".template.generated";
-    protected static string ProjectName => "ExpressionFramework";
-    protected override string RootNamespace => $"{ProjectName}.Domain";
-    protected static string CodeGenerationRootNamespace => $"{ProjectName}.CodeGeneration";
+    protected override string ProjectName => "ExpressionFramework";
     protected override Type BuilderClassCollectionType => typeof(IEnumerable<>);
     protected override bool AddBackingFieldsForCollectionProperties => true;
     protected override bool AddPrivateSetters => true;
-
-    protected override string GetFullBasePath()
-        => Directory.GetCurrentDirectory().EndsWith(ProjectName)
-            ? System.IO.Path.Combine(Directory.GetCurrentDirectory(), @"src/")
-            : System.IO.Path.Combine(Directory.GetCurrentDirectory(), @"../../../../");
-
-    protected override string[] GetCustomBuilderTypes()
-        => GetAbstractModels().Select(x => x.GetEntityClassName() ).ToArray();
-
-    protected override Dictionary<string, string> GetCustomDefaultValueForBuilderClassConstructorValues()
-        => new(GetAbstractModels().Select(x => new KeyValuePair<string, string>($"{RootNamespace}.{x.GetEntityClassName()}", "null")));
-
-    protected override Dictionary<string, string> GetBuilderNamespaceMappings()
-        => new(GetCustomBuilderTypes()
-            .Select(x => new KeyValuePair<string, string>($"{RootNamespace}.{x}s", $"{RootNamespace}.Builders.{x}s"))
-            .Concat(new[] { new KeyValuePair<string, string>(RootNamespace, $"{RootNamespace}.Builders") }));
-
-    protected override Dictionary<string, string> GetModelMappings() => new
-    (
-        new[] { new KeyValuePair<string, string>($"{CodeGenerationRootNamespace}.Models.I", $"{RootNamespace}.") }
-        .Concat(GetAbstractModels().Select(x => new KeyValuePair<string, string>($"{CodeGenerationRootNamespace}.Models.{x.Name}s.I", $"{RootNamespace}.{x.Name}s.")))
-        .Concat(new[]
-        {
-            new KeyValuePair<string, string>($"{CodeGenerationRootNamespace}.Models.Domains.", $"{RootNamespace}.Domains."),
-            new KeyValuePair<string, string>($"{CodeGenerationRootNamespace}.I", $"{RootNamespace}.I")
-        })
-    );
-
-    protected override string[] GetNonDomainTypes()
-        => GetType().Assembly.GetExportedTypes()
-            .Where(x => x.IsInterface && x.Namespace == CodeGenerationRootNamespace)
-            .Select(x => $"{RootNamespace}.{x.Name}")
-            .ToArray();
-
-    protected ITypeBase[] GetCoreModels()
-        => MapCodeGenerationModelsToDomain(
-            GetType().Assembly.GetExportedTypes()
-                .Where(x => x.IsInterface && x.Namespace == $"{CodeGenerationRootNamespace}.Models" && !GetCustomBuilderTypes().Contains(x.GetEntityClassName())));
-
-    protected ITypeBase[] GetAbstractModels()
-        => MapCodeGenerationModelsToDomain(
-            GetType().Assembly.GetExportedTypes()
-                .Where(x => x.IsInterface && x.GetInterfaces().Length == 1)
-                .Select(x => x.GetInterfaces()[0])
-                .Distinct());
-
-    protected ITypeBase[] GetOverrideModels(Type abstractType)
-        => MapCodeGenerationModelsToDomain(
-            GetType().Assembly.GetExportedTypes()
-                .Where(x => x.IsInterface && x.GetInterfaces().FirstOrDefault() == abstractType));
 }

--- a/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
+++ b/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
@@ -14,7 +14,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.21" />
-      <PackageReference Include="pauldeen79.TextTemplateTransformationFramework.Runtime" Version="0.1.26" />
+      <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.24" />
     </ItemGroup>
 </Project>

--- a/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
+++ b/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
@@ -15,5 +15,6 @@
 
     <ItemGroup>
       <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.21" />
+      <PackageReference Include="pauldeen79.TextTemplateTransformationFramework.Runtime" Version="0.1.26" />
     </ItemGroup>
 </Project>

--- a/src/ExpressionFramework.CodeGeneration/GlobalUsings.cs
+++ b/src/ExpressionFramework.CodeGeneration/GlobalUsings.cs
@@ -3,6 +3,7 @@ global using System.ComponentModel.DataAnnotations;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using CrossCutting.Common;
+global using CrossCutting.Common.Extensions;
 global using CrossCutting.Common.Results;
 global using ExpressionFramework.CodeGeneration.CodeGenerationProviders;
 global using ExpressionFramework.CodeGeneration.Models;

--- a/src/ExpressionFramework.CodeGeneration/Program.cs
+++ b/src/ExpressionFramework.CodeGeneration/Program.cs
@@ -16,9 +16,10 @@ internal static class Program
         var settings = new CodeGenerationSettings(basePath, generateMultipleFiles, false, dryRun);
 
         // Generate code
+        var generationTypeNames = new[] { "Entities", "Builders", "BuilderFactory" };
         var generators = typeof(ExpressionFrameworkCSharpClassBase).Assembly.GetExportedTypes().Where(x => x.BaseType == typeof(ExpressionFrameworkCSharpClassBase)).ToArray();
-        var generationTypes = generators.Where(x => x.Name.EndsWithAny("Entities", "Builders", "Factory"));
-        var scaffoldingTypes = generators.Where(x => !x.Name.EndsWithAny("Entities", "Builders", "Factory"));
+        var generationTypes = generators.Where(x => x.Name.EndsWithAny(generationTypeNames));
+        var scaffoldingTypes = generators.Where(x => !x.Name.EndsWithAny(generationTypeNames));
         _ = generationTypes.Select(x => (ExpressionFrameworkCSharpClassBase)Activator.CreateInstance(x)!).Select(x => GenerateCode.For(settings.ForGeneration(), multipleContentBuilder, x)).ToArray();
         _ = scaffoldingTypes.Select(x => (ExpressionFrameworkCSharpClassBase)Activator.CreateInstance(x)!).Select(x => GenerateCode.For(settings.ForScaffolding(), multipleContentBuilder, x)).ToArray();
 

--- a/src/ExpressionFramework.CodeGeneration/Program.cs
+++ b/src/ExpressionFramework.CodeGeneration/Program.cs
@@ -16,34 +16,11 @@ internal static class Program
         var settings = new CodeGenerationSettings(basePath, generateMultipleFiles, false, dryRun);
 
         // Generate code
-        GenerateCode.For<CoreBuilders>(settings, multipleContentBuilder);
-        GenerateCode.For<CoreEntities>(settings, multipleContentBuilder);
-
-        GenerateCode.For<AbstractBuilders>(settings, multipleContentBuilder);
-        GenerateCode.For<AbstractNonGenericBuilders>(settings, multipleContentBuilder);
-        GenerateCode.For<AbstractEntities>(settings, multipleContentBuilder);
-
-        GenerateCode.For<OverrideExpressionBuilders>(settings, multipleContentBuilder);
-        GenerateCode.For<OverrideExpressionEntities>(settings, multipleContentBuilder);
-        GenerateCode.For<ExpressionBuilderFactory>(settings, multipleContentBuilder);
-
-        GenerateCode.For<OverrideOperatorBuilders>(settings, multipleContentBuilder);
-        GenerateCode.For<OverrideOperatorEntities>(settings, multipleContentBuilder);
-        GenerateCode.For<OperatorBuilderFactory>(settings, multipleContentBuilder);
-
-        GenerateCode.For<OverrideEvaluatableBuilders>(settings, multipleContentBuilder);
-        GenerateCode.For<OverrideEvaluatableEntities>(settings, multipleContentBuilder);
-        GenerateCode.For<EvaluatableBuilderFactory>(settings, multipleContentBuilder);
-
-        GenerateCode.For<OverrideAggregatorBuilders>(settings, multipleContentBuilder);
-        GenerateCode.For<OverrideAggregatorEntities>(settings, multipleContentBuilder);
-        GenerateCode.For<AggregatorBuilderFactory>(settings, multipleContentBuilder);
-
-        settings = new CodeGenerationSettings(basePath, generateMultipleFiles, true, dryRun);
-        GenerateCode.For<Aggregators>(settings, multipleContentBuilder);
-        GenerateCode.For<Evaluatables>(settings, multipleContentBuilder);
-        GenerateCode.For<Expressions>(settings, multipleContentBuilder);
-        GenerateCode.For<Operators>(settings, multipleContentBuilder);
+        var generators = typeof(ExpressionFrameworkCSharpClassBase).Assembly.GetExportedTypes().Where(x => x.BaseType == typeof(ExpressionFrameworkCSharpClassBase)).ToArray();
+        var generationTypes = generators.Where(x => x.Name.EndsWithAny("Entities", "Builders", "Factory"));
+        var scaffoldingTypes = generators.Where(x => !x.Name.EndsWithAny("Entities", "Builders", "Factory"));
+        _ = generationTypes.Select(x => (ExpressionFrameworkCSharpClassBase)Activator.CreateInstance(x)!).Select(x => GenerateCode.For(settings.ForGeneration(), multipleContentBuilder, x)).ToArray();
+        _ = scaffoldingTypes.Select(x => (ExpressionFrameworkCSharpClassBase)Activator.CreateInstance(x)!).Select(x => GenerateCode.For(settings.ForScaffolding(), multipleContentBuilder, x)).ToArray();
 
         // Log output to console
         if (string.IsNullOrEmpty(basePath))

--- a/src/ExpressionFramework.CodeGeneration/Program.cs
+++ b/src/ExpressionFramework.CodeGeneration/Program.cs
@@ -53,7 +53,7 @@ internal static class Program
         else
         {
             Console.WriteLine($"Code generation completed, check the output in {basePath}");
-            Console.WriteLine("Generated files:");
+            Console.WriteLine($"Generated files: {multipleContentBuilder.Contents.Count()}");
             foreach (var content in multipleContentBuilder.Contents)
             {
                 Console.WriteLine(content.FileName);


### PR DESCRIPTION
- Dynamically determine code generators, instead of manually coding it. You can now simply add a new code generator, and it will be used by the program automatically.
- Removed code from the code generation base class. This is now part of ModelFramework.CodeGeneration.