### PR TITLE
Evaluate typed

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # //TODO
 expressions:
-- Add SequenceExpression, which evaluates all expressions, and returns them as a sequence
 - Add RangeExpression, which creates a range from minimum to maximum value (optionally with step)
 - Add StringJoinExpression, which joins multiple values using a separator
 - Add PadLeft and PadRight string expressions

--- a/src/ExpressionFramework.CodeGeneration/Models/Expressions/IBooleanConstantExpression.cs
+++ b/src/ExpressionFramework.CodeGeneration/Models/Expressions/IBooleanConstantExpression.cs
@@ -1,0 +1,6 @@
+﻿namespace ExpressionFramework.CodeGeneration.Models.Expressions;
+
+public interface IBooleanConstantExpression : IExpression
+{
+    bool Value { get; }
+}

--- a/src/ExpressionFramework.CodeGeneration/Models/Expressions/IInt32ConstantExpression.cs
+++ b/src/ExpressionFramework.CodeGeneration/Models/Expressions/IInt32ConstantExpression.cs
@@ -1,0 +1,6 @@
+﻿namespace ExpressionFramework.CodeGeneration.Models.Expressions;
+
+public interface IInt32ConstantExpression : IExpression
+{
+    int Value { get; }
+}

--- a/src/ExpressionFramework.CodeGeneration/Models/Expressions/ISequenceExpression.cs
+++ b/src/ExpressionFramework.CodeGeneration/Models/Expressions/ISequenceExpression.cs
@@ -1,0 +1,7 @@
+﻿namespace ExpressionFramework.CodeGeneration.Models.Expressions;
+
+public interface ISequenceExpression : IExpression
+{
+    [Required]
+    IReadOnlyCollection<IExpression> Expressions { get; }
+}

--- a/src/ExpressionFramework.CodeGeneration/Models/Expressions/IStringConstantExpression.cs
+++ b/src/ExpressionFramework.CodeGeneration/Models/Expressions/IStringConstantExpression.cs
@@ -1,0 +1,6 @@
+﻿namespace ExpressionFramework.CodeGeneration.Models.Expressions;
+
+public interface IStringConstantExpression : IExpression
+{
+    string Value { get; }
+}

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AllExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AllExpressionTests.cs
@@ -129,6 +129,132 @@ public class AllExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new AllExpression(new ConstantExpression(false));
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Context cannot be empty");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Not_Of_Type_Enumerable()
+    {
+        // Arrange
+        var sut = new AllExpression(new ConstantExpression(false));
+
+        // Act
+        var result = sut.EvaluateTyped(123);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Context is not of type enumerable");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_PredicateExpression_Is_empty()
+    {
+        // Arrange
+        var sut = new AllExpression(null!);
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { "A", "B", "C" });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Predicate is required");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_True_When_Context_Is_Empty_Enumerable()
+    {
+        // Arrange
+        var sut = new AllExpression(new ConstantExpression(false));
+
+        // Act
+        var result = sut.EvaluateTyped(Enumerable.Empty<object>());
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(true);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_PredicateExpression_Returns_Invalid()
+    {
+        // Arrange
+        var sut = new AllExpression(new InvalidExpression("Something bad happened"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Something bad happened");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Error_When_PredicateExpression_Returns_Error()
+    {
+        // Arrange
+        var sut = new AllExpression(new ErrorExpression("Something bad happened"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Something bad happened");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_PredicateExpression_Returns_Non_Boolean_Value()
+    {
+        // Arrange
+        var sut = new AllExpression(new ConstantExpression("None boolean value"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Predicate did not return a boolean value");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_False_When_Enumerable_Context_Does_Not_Contain_Any_Item_That_Conforms_To_PredicateExpression()
+    {
+        // Arrange
+        var sut = new AllExpression(new DelegateExpression(x => x is int i && i > 10));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(false);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Correct_Result_On_Filled_Enumerable()
+    {
+        // Arrange
+        var sut = new AllExpression(new DelegateExpression(x => x is int i && i > 1));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(false);
+    }
+
+    [Fact]
     public void ValidateContext_Returns_Empty_Sequence_When_All_Is_Well()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AnyExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AnyExpressionTests.cs
@@ -129,6 +129,132 @@ public class AnyExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new AnyExpression(null);
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Context cannot be empty");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Not_Of_Type_Enumerable()
+    {
+        // Arrange
+        var sut = new AnyExpression(null);
+
+        // Act
+        var result = sut.EvaluateTyped(123);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Context is not of type enumerable");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_False_When_Context_Is_Empty_Enumerable()
+    {
+        // Arrange
+        var sut = new AnyExpression(null);
+
+        // Act
+        var result = sut.EvaluateTyped(Enumerable.Empty<object>());
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(false);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_PredicateExpression_Returns_Invalid()
+    {
+        // Arrange
+        var sut = new AnyExpression(new InvalidExpression("Something bad happened"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Something bad happened");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Error_When_PredicateExpression_Returns_Error()
+    {
+        // Arrange
+        var sut = new AnyExpression(new ErrorExpression("Something bad happened"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Something bad happened");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_PredicateExpression_Returns_Non_Boolean_Value()
+    {
+        // Arrange
+        var sut = new AnyExpression(new ConstantExpression("None boolean value"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Predicate did not return a boolean value");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_False_When_Enumerable_Context_Does_Not_Contain_Any_Item_That_Conforms_To_PredicateExpression()
+    {
+        // Arrange
+        var sut = new AnyExpression(new DelegateExpression(x => x is int i && i > 10));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(false);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Correct_Result_On_Filled_Enumerable_Without_Predicate()
+    {
+        // Arrange
+        var sut = new AnyExpression(null);
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(true);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Correct_Result_On_Filled_Enumerable_With_Predicate()
+    {
+        // Arrange
+        var sut = new AnyExpression(new DelegateExpression(x => x is int i && i > 1));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(true);
+    }
+
+    [Fact]
     public void ValidateContext_Returns_Empty_Sequence_When_All_Is_Well()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/BooleanConstantExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/BooleanConstantExpressionTests.cs
@@ -1,0 +1,49 @@
+﻿namespace ExpressionFramework.Domain.Tests.Unit.Expressions;
+
+public class BooleanConstantExpressionTests
+{
+    [Fact]
+    public void Can_Evaluate_Boolean()
+    {
+        // Arrange
+        var sut = new BooleanConstantExpression(true);
+
+        // Act
+        var result = sut.Evaluate(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEquivalentTo(true);
+    }
+
+    [Fact]
+    public void Can_Evaluate_Boolean_Typed()
+    {
+        // Arrange
+        var sut = new BooleanConstantExpression(true);
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Can_Determine_Descriptor_Provider()
+    {
+        // Arrange
+        var sut = new ReflectionExpressionDescriptorProvider(typeof(BooleanConstantExpression));
+
+        // Act
+        var result = sut.Get();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be(nameof(BooleanConstantExpression));
+        result.Parameters.Should().ContainSingle();
+        result.ReturnValues.Should().ContainSingle();
+        result.ContextIsRequired.Should().BeNull();
+    }
+}

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/CountExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/CountExpressionTests.cs
@@ -129,6 +129,132 @@ public class CountExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new CountExpression(null);
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Context cannot be empty");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Not_Of_Type_Enumerable()
+    {
+        // Arrange
+        var sut = new CountExpression(null);
+
+        // Act
+        var result = sut.EvaluateTyped(123);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Context is not of type enumerable");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Zero_When_Context_Is_Empty_Enumerable()
+    {
+        // Arrange
+        var sut = new CountExpression(null);
+
+        // Act
+        var result = sut.EvaluateTyped(Enumerable.Empty<object>());
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(0);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_PredicateExpression_Returns_Invalid()
+    {
+        // Arrange
+        var sut = new CountExpression(new InvalidExpression("Something bad happened"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Something bad happened");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Error_When_PredicateExpression_Returns_Error()
+    {
+        // Arrange
+        var sut = new CountExpression(new ErrorExpression("Something bad happened"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Something bad happened");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_PredicateExpression_Returns_Non_Boolean_Value()
+    {
+        // Arrange
+        var sut = new CountExpression(new ConstantExpression("None boolean value"));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Predicate did not return a boolean value");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Zero_When_Enumerable_Context_Does_Not_Contain_Any_Item_That_Conforms_To_PredicateExpression()
+    {
+        // Arrange
+        var sut = new CountExpression(new DelegateExpression(x => x is int i && i > 10));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(0);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Correct_Result_On_Filled_Enumerable_Without_Predicate()
+    {
+        // Arrange
+        var sut = new CountExpression(null);
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(3);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Correct_Result_On_Filled_Enumerable_With_Predicate()
+    {
+        // Arrange
+        var sut = new CountExpression(new DelegateExpression(x => x is int i && i > 1));
+
+        // Act
+        var result = sut.EvaluateTyped(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(2);
+    }
+
+    [Fact]
     public void ValidateContext_Returns_Empty_Sequence_When_All_Is_Well()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/EqualsExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/EqualsExpressionTests.cs
@@ -35,6 +35,54 @@ public class EqualsExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Error_When_Evaluation_Of_FirstExpression_Fails()
+    {
+        // Arrange
+        var firstExpression = new ErrorExpression("Kaboom");
+        var secondExpression = new ConstantExpression("2");
+        var sut = new EqualsExpression(firstExpression, secondExpression);
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Error);
+        actual.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Error_When_Evaluation_Of_SecondExpression_Fails()
+    {
+        // Arrange
+        var firstExpression = new ConstantExpression("1");
+        var secondExpression = new ErrorExpression("Kaboom");
+        var expression = new EqualsExpression(firstExpression, secondExpression);
+
+        // Act
+        var actual = expression.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Error);
+        actual.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Correct_Value_On_Success()
+    {
+        // Arrange
+        var firstExpression = new ConstantExpression("1");
+        var secondExpression = new ConstantExpression("1");
+        var expression = new EqualsExpression(firstExpression, secondExpression);
+
+        // Act
+        var actual = expression.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Ok);
+        actual.Value.Should().Be(true);
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FalseExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FalseExpressionTests.cs
@@ -17,6 +17,20 @@ public class FalseExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Success_With_Value_True()
+    {
+        // Arrange
+        var sut = new FalseExpression();
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(false);
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FirstExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FirstExpressionTests.cs
@@ -129,6 +129,20 @@ public class FirstExpressionTests
     }
 
     [Fact]
+    public void Evaluate_Returns_Correct_Result_On_Filled_Enumerable_With_Typed_Predicate()
+    {
+        // Arrange
+        var sut = new FirstExpression(new BooleanConstantExpression(true));
+
+        // Act
+        var result = sut.Evaluate(new[] { 1, 2, 3 });
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEquivalentTo(1);
+    }
+
+    [Fact]
     public void ValidateContext_Returns_Empty_Sequence_When_All_Is_Well()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/Int32ConstantExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/Int32ConstantExpressionTests.cs
@@ -1,0 +1,49 @@
+﻿namespace ExpressionFramework.Domain.Tests.Unit.Expressions;
+
+public class Int32ConstantExpressionTests
+{
+    [Fact]
+    public void Can_Evaluate_Int32()
+    {
+        // Arrange
+        var sut = new Int32ConstantExpression(1);
+
+        // Act
+        var result = sut.Evaluate(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEquivalentTo(1);
+    }
+
+    [Fact]
+    public void Can_Evaluate_Int32_Typed()
+    {
+        // Arrange
+        var sut = new Int32ConstantExpression(1);
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(1);
+    }
+
+    [Fact]
+    public void Can_Determine_Descriptor_Provider()
+    {
+        // Arrange
+        var sut = new ReflectionExpressionDescriptorProvider(typeof(Int32ConstantExpression));
+
+        // Act
+        var result = sut.Get();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be(nameof(Int32ConstantExpression));
+        result.Parameters.Should().ContainSingle();
+        result.ReturnValues.Should().ContainSingle();
+        result.ContextIsRequired.Should().BeNull();
+    }
+}

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/LeftExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/LeftExpressionTests.cs
@@ -72,6 +72,76 @@ public class LeftExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_LeftValue_From_Context_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new LeftExpression(2);
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Ok);
+        actual.Value.Should().Be("te");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Too_Short()
+    {
+        // Arrange
+        var sut = new LeftExpression(2);
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Length must refer to a location within the string");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new LeftExpression(2);
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Error_When_LengthExpression_Evaluation_Returns_Error()
+    {
+        // Arrange
+        var sut = new LeftExpression(new ErrorExpression("Kaboom"));
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Error);
+        actual.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_LengthExpression_Evaluation_Returns_Non_Integer_Value()
+    {
+        // Arrange
+        var sut = new LeftExpression(new ConstantExpression("no integer in here"));
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("LengthExpression did not return an integer");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NotExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NotExpressionTests.cs
@@ -17,6 +17,20 @@ public class NotExpressionTests
     }
 
     [Fact]
+    public void Evaluate_Returns_Invalid_When_Context_Is_Of_Wrong_Type()
+    {
+        // Arrange
+        var sut = new NotExpression();
+
+        // Act
+        var result = sut.Evaluate(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Context must be of type boolean");
+    }
+
+    [Fact]
     public void EvaluateTyped_Returns_Success_With_Negated_BooleanValue()
     {
         // Arrange
@@ -31,13 +45,13 @@ public class NotExpressionTests
     }
 
     [Fact]
-    public void Evaluate_Returns_Invalid_When_Context_Is_Of_Wrong_Type()
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Of_Wrong_Type()
     {
         // Arrange
         var sut = new NotExpression();
 
         // Act
-        var result = sut.Evaluate(null);
+        var result = sut.EvaluateTyped(null);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Invalid);

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NotExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NotExpressionTests.cs
@@ -17,6 +17,20 @@ public class NotExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Success_With_Negated_BooleanValue()
+    {
+        // Arrange
+        var sut = new NotExpression();
+
+        // Act
+        var result = sut.EvaluateTyped(false);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(true);
+    }
+
+    [Fact]
     public void Evaluate_Returns_Invalid_When_Context_Is_Of_Wrong_Type()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/RightExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/RightExpressionTests.cs
@@ -72,6 +72,76 @@ public class RightExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_LeftValue_From_Context_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new RightExpression(2);
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Ok);
+        actual.Value.Should().Be("st");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Too_Short()
+    {
+        // Arrange
+        var sut = new RightExpression(2);
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Length must refer to a location within the string");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new RightExpression(2);
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Error_When_LengthExpression_Evaluation_Returns_Error()
+    {
+        // Arrange
+        var sut = new RightExpression(new ErrorExpression("Kaboom"));
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Error);
+        actual.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_LengthExpression_Evaluation_Returns_Non_Integer_Value()
+    {
+        // Arrange
+        var sut = new RightExpression(new ConstantExpression("no integer in here"));
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("LengthExpression did not return an integer");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SequenceExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SequenceExpressionTests.cs
@@ -1,0 +1,77 @@
+﻿namespace ExpressionFramework.Domain.Tests.Unit.Expressions;
+
+public class SequenceExpressionTests
+{
+    [Fact]
+    public void Evaluate_Returns_Invalid_When_One_Expression_Returns_Invalid()
+    {
+        // Arrange
+        var sut = new SequenceExpression(new Expression[] { new ConstantExpression(1), new ConstantExpression(2), new InvalidExpression("Message") });
+
+        // Act
+        var result = sut.Evaluate(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Message");
+    }
+
+    [Fact]
+    public void Evaluate_Returns_Error_When_One_Expression_Returns_Error()
+    {
+        // Arrange
+        var sut = new SequenceExpression(new Expression[] { new ConstantExpression(1), new ConstantExpression(2), new ErrorExpression("Kaboom") });
+
+        // Act
+        var result = sut.Evaluate(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void Evaluate_Returns_Empty_Sequence_When_Expressions_Are_Empty()
+    {
+        // Arrange
+        var sut = new SequenceExpression(Enumerable.Empty<Expression>());
+
+        // Act
+        var result = sut.Evaluate(null).TryCast<IEnumerable<object?>>();
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Evaluate_Returns_Filled_Sequence_When_Expressions_Are_Not_Empty()
+    {
+        // Arrange
+        var sut = new SequenceExpression(new Expression[] { new ConstantExpression(1), new ConstantExpression(2), new ConstantExpression(3) });
+
+        // Act
+        var result = sut.Evaluate(null).TryCast<IEnumerable<object?>>();
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public void Can_Determine_Descriptor_Provider()
+    {
+        // Arrange
+        var sut = new ReflectionExpressionDescriptorProvider(typeof(SequenceExpression));
+
+        // Act
+        var result = sut.Get();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be(nameof(SequenceExpression));
+        result.Parameters.Should().ContainSingle();
+        result.ReturnValues.Should().HaveCount(2);
+        result.ContextIsRequired.Should().BeNull();
+    }
+}

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SequenceExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SequenceExpressionTests.cs
@@ -59,6 +59,62 @@ public class SequenceExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_One_Expression_Returns_Invalid()
+    {
+        // Arrange
+        var sut = new SequenceExpression(new Expression[] { new ConstantExpression(1), new ConstantExpression(2), new InvalidExpression("Message") });
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Message");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Error_When_One_Expression_Returns_Error()
+    {
+        // Arrange
+        var sut = new SequenceExpression(new Expression[] { new ConstantExpression(1), new ConstantExpression(2), new ErrorExpression("Kaboom") });
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Empty_Sequence_When_Expressions_Are_Empty()
+    {
+        // Arrange
+        var sut = new SequenceExpression(Enumerable.Empty<Expression>());
+
+        // Act
+        var result = sut.EvaluateTyped(null).TryCast<IEnumerable<object?>>();
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Filled_Sequence_When_Expressions_Are_Not_Empty()
+    {
+        // Arrange
+        var sut = new SequenceExpression(new Expression[] { new ConstantExpression(1), new ConstantExpression(2), new ConstantExpression(3) });
+
+        // Act
+        var result = sut.EvaluateTyped(null).TryCast<IEnumerable<object?>>();
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SequenceExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SequenceExpressionTests.cs
@@ -93,7 +93,7 @@ public class SequenceExpressionTests
         var sut = new SequenceExpression(Enumerable.Empty<Expression>());
 
         // Act
-        var result = sut.EvaluateTyped(null).TryCast<IEnumerable<object?>>();
+        var result = sut.EvaluateTyped(null);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
@@ -107,7 +107,7 @@ public class SequenceExpressionTests
         var sut = new SequenceExpression(new Expression[] { new ConstantExpression(1), new ConstantExpression(2), new ConstantExpression(3) });
 
         // Act
-        var result = sut.EvaluateTyped(null).TryCast<IEnumerable<object?>>();
+        var result = sut.EvaluateTyped(null);
 
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringConcatenateExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringConcatenateExpressionTests.cs
@@ -64,6 +64,67 @@ public class StringConcatenateExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Expressions_Is_Empty()
+    {
+        // Arrange
+        var sut = new StringConcatenateExpression(Enumerable.Empty<Expression>());
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("At least one expression is required");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Expressions_Contains_Non_String_Value()
+    {
+        // Arrange
+        var sut = new StringConcatenateExpression(new[] { new ConstantExpression(false) });
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ErrorMessage.Should().Be("Expression must be of type string");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Error_When_Expressions_Returns_One_Item_With_Error_Result()
+    {
+        // Arrange
+        var sut = new StringConcatenateExpression(new[] { new ErrorExpression("Kaboom") });
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Concatated_String_When_All_Expressions_Contain_String_Value()
+    {
+        // Arrange
+        var sut = new StringConcatenateExpression(new[]
+        {
+            new ConstantExpression("a"),
+            new ConstantExpression("b"),
+            new ConstantExpression("c")
+        });
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be("abc");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_Item_When_Expressions_Is_Empty()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringConstantExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringConstantExpressionTests.cs
@@ -1,0 +1,49 @@
+﻿namespace ExpressionFramework.Domain.Tests.Unit.Expressions;
+
+public class StringConstantExpressionTests
+{
+    [Fact]
+    public void Can_Evaluate_String()
+    {
+        // Arrange
+        var sut = new StringConstantExpression("test");
+
+        // Act
+        var result = sut.Evaluate(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().BeEquivalentTo("test");
+    }
+
+    [Fact]
+    public void Can_Evaluate_String_Typed()
+    {
+        // Arrange
+        var sut = new StringConstantExpression("test");
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be("test");
+    }
+
+    [Fact]
+    public void Can_Determine_Descriptor_Provider()
+    {
+        // Arrange
+        var sut = new ReflectionExpressionDescriptorProvider(typeof(StringConstantExpression));
+
+        // Act
+        var result = sut.Get();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be(nameof(StringConstantExpression));
+        result.Parameters.Should().ContainSingle();
+        result.ReturnValues.Should().ContainSingle();
+        result.ContextIsRequired.Should().BeNull();
+    }
+}

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringLengthExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringLengthExpressionTests.cs
@@ -43,6 +43,46 @@ public class StringLengthExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Length_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new StringLengthExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped("some");
+
+        // Assert
+        actual.GetValueOrThrow().Should().Be(4);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_0_When_Context_Is_EmptyString()
+    {
+        // Arrange
+        var sut = new StringLengthExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.GetValueOrThrow().Should().Be(0);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new StringLengthExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SubstringExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SubstringExpressionTests.cs
@@ -100,6 +100,104 @@ public class SubstringExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Substring_From_Context_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new SubstringExpression(1, 1);
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Ok);
+        actual.Value.Should().Be("e");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Too_Short()
+    {
+        // Arrange
+        var sut = new SubstringExpression(1, 1);
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Index and length must refer to a location within the string");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new SubstringExpression(1, 1);
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_IndexExpression_Result_Is_Invalid()
+    {
+        // Arrange
+        var sut = new SubstringExpression(new InvalidExpression("Kaboom"), new ConstantExpression(1));
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_IndexExpression_Result_Value_Is_Not_An_Integer()
+    {
+        // Arrange
+        var sut = new SubstringExpression(new ConstantExpression("not an integer"), new ConstantExpression(1));
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("IndexExpression did not return an integer");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_LengthExpression_Result_Is_Invalid()
+    {
+        // Arrange
+        var sut = new SubstringExpression(new ConstantExpression(1), new InvalidExpression("Kaboom"));
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Kaboom");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_LengthExpression_Result_Value_Is_Not_An_Integer()
+    {
+        // Arrange
+        var sut = new SubstringExpression(new ConstantExpression(1), new ConstantExpression("not an integer"));
+
+        // Act
+        var actual = sut.EvaluateTyped("test");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("LengthExpression did not return an integer");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToLowerCaseExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToLowerCaseExpressionTests.cs
@@ -43,6 +43,47 @@ public class ToLowerCaseExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_LowerCase_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new ToLowerCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped("LOWER");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Ok);
+        actual.Value.Should().Be("lower");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_EmptyString_When_Context_Is_EmptyString()
+    {
+        // Arrange
+        var sut = new ToLowerCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.GetValueOrThrow().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new ToLowerCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToPascalCaseExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToPascalCaseExpressionTests.cs
@@ -43,6 +43,47 @@ public class ToPascalCaseExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_PascalCase_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new ToPascalCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped("Pascal");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Ok);
+        actual.Value.Should().Be("pascal");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_EmptyString_When_Context_Is_EmptyString()
+    {
+        // Arrange
+        var sut = new ToPascalCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.GetValueOrThrow().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new ToPascalCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToUpperCaseExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToUpperCaseExpressionTests.cs
@@ -43,6 +43,47 @@ public class ToUpperCaseExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_UpperCase_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new ToUpperCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped("Upper");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Ok);
+        actual.Value.Should().Be("UPPER");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_EmptyString_When_Context_Is_EmptyString()
+    {
+        // Arrange
+        var sut = new ToUpperCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.GetValueOrThrow().Should().BeEquivalentTo(string.Empty);
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new ToUpperCaseExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimEndExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimEndExpressionTests.cs
@@ -56,6 +56,59 @@ public class TrimEndExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Trimmed_Expression_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new TrimEndExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(" trim ");
+
+        // Assert
+        actual.GetValueOrThrow().Should().Be(" trim");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Trimmed_Expression_With_TrimChars_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new TrimEndExpression(new[] { '0' });
+
+        // Act
+        var actual = sut.EvaluateTyped("0trim0");
+
+        // Assert
+        actual.GetValueOrThrow().Should().Be("0trim");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_EmptyString_When_Context_Is_EmptyString()
+    {
+        // Arrange
+        var sut = new TrimEndExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.GetValueOrThrow().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new TrimEndExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimExpressionTests.cs
@@ -56,6 +56,60 @@ public class TrimExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Trimmed_Expression_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new TrimExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(" trim ");
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Ok);
+        actual.Value.Should().Be("trim");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Trimmed_Expression_With_TrimChars_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new TrimExpression(new[] { '0' });
+
+        // Act
+        var actual = sut.EvaluateTyped("0trim0");
+
+        // Assert
+        actual.GetValueOrThrow().Should().Be("trim");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_EmptyString_When_Context_Is_EmptyString()
+    {
+        // Arrange
+        var sut = new TrimExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.GetValueOrThrow().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new TrimExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimStartExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimStartExpressionTests.cs
@@ -56,6 +56,59 @@ public class TrimStartExpressionTests
     }
 
     [Fact]
+    public void EvaluateTyped_Returns_Trimmed_Expression_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new TrimStartExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(" trim ");
+
+        // Assert
+        actual.GetValueOrThrow().Should().Be("trim ");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Trimmed_Expression_With_TrimChars_When_Context_Is_NonEmptyString()
+    {
+        // Arrange
+        var sut = new TrimStartExpression(new[] { '0' });
+
+        // Act
+        var actual = sut.EvaluateTyped("0trim0");
+
+        // Assert
+        actual.GetValueOrThrow().Should().Be("trim0");
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_EmptyString_When_Context_Is_EmptyString()
+    {
+        // Arrange
+        var sut = new TrimStartExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(string.Empty);
+
+        // Assert
+        actual.GetValueOrThrow().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EvaluateTyped_Returns_Invalid_When_Context_Is_Null()
+    {
+        // Arrange
+        var sut = new TrimStartExpression();
+
+        // Act
+        var actual = sut.EvaluateTyped(null);
+
+        // Assert
+        actual.Status.Should().Be(ResultStatus.Invalid);
+        actual.ErrorMessage.Should().Be("Context must be of type string");
+    }
+
+    [Fact]
     public void ValidateContext_Returns_ValidationError_When_Value_Is_Not_String()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrueExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrueExpressionTests.cs
@@ -17,6 +17,20 @@ public class TrueExpressionTests
     }
 
     [Fact]
+    public void EvaluatTyped_Returns_Success_With_Value_True()
+    {
+        // Arrange
+        var sut = new TrueExpression();
+
+        // Act
+        var result = sut.EvaluateTyped(null);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().Be(true);
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain/EnumerableExpression.cs
+++ b/src/ExpressionFramework.Domain/EnumerableExpression.cs
@@ -26,31 +26,31 @@ public static class EnumerableExpression
         return Result<IEnumerable<object?>>.Success(results.Select(x => x.Value));
     }
 
-    public static Result<object?> GetRequiredScalarValue(object? context,
-                                                         Expression? predicate,
-                                                         Func<IEnumerable<object?>, Result<object?>> delegateWithoutPredicate,
-                                                         Func<IEnumerable<ItemResult>, Result<object?>>? delegateWithPredicate = null,
-                                                         Func<IEnumerable<object?>, Result<IEnumerable<object?>>>? selectorDelegate = null,
-                                                         bool predicateIsRequired = false)
+    public static Result<T> GetRequiredScalarValue<T>(object? context,
+                                                      Expression? predicate,
+                                                      Func<IEnumerable<object?>, Result<T>> delegateWithoutPredicate,
+                                                      Func<IEnumerable<ItemResult>, Result<T>>? delegateWithPredicate = null,
+                                                      Func<IEnumerable<object?>, Result<IEnumerable<object?>>>? selectorDelegate = null,
+                                                      bool predicateIsRequired = false)
         => GetScalarValue
         (
             context,
             predicate,
             delegateWithoutPredicate,
             delegateWithPredicate,
-            _ => Result<object?>.Invalid("Enumerable is empty"),
-            _ => Result<object?>.Invalid("None of the items conform to the supplied predicate"),
+            _ => Result<T>.Invalid("Enumerable is empty"),
+            _ => Result<T>.Invalid("None of the items conform to the supplied predicate"),
             selectorDelegate,
             predicateIsRequired
         );
 
-    public static Result<object?> GetOptionalScalarValue(object? context,
-                                                         Expression? predicate,
-                                                         Func<IEnumerable<object?>, Result<object?>> delegateWithoutPredicate,
-                                                         Func<IEnumerable<ItemResult>, Result<object?>>? delegateWithPredicate = null,
-                                                         Func<object?, Result<object?>>? defaultValueDelegate = null,
-                                                         Func<IEnumerable<object?>, Result<IEnumerable<object?>>>? selectorDelegate = null,
-                                                         bool predicateIsRequired = false)
+    public static Result<T> GetOptionalScalarValue<T>(object? context,
+                                                      Expression? predicate,
+                                                      Func<IEnumerable<object?>, Result<T>> delegateWithoutPredicate,
+                                                      Func<IEnumerable<ItemResult>, Result<T>>? delegateWithPredicate = null,
+                                                      Func<object?, Result<T>>? defaultValueDelegate = null,
+                                                      Func<IEnumerable<object?>, Result<IEnumerable<object?>>>? selectorDelegate = null,
+                                                      bool predicateIsRequired = false)
         => GetScalarValue
         (
             context,
@@ -63,9 +63,9 @@ public static class EnumerableExpression
             predicateIsRequired
         );
 
-    public static Result<object?> GetAggregateValue(object? context,
-                                                    Func<IEnumerable<object?>, Result<object?>> aggregateDelegate,
-                                                    Expression? selectorExpression = null)
+    public static Result<T> GetAggregateValue<T>(object? context,
+                                                 Func<IEnumerable<object?>, Result<T>> aggregateDelegate,
+                                                 Expression? selectorExpression = null)
         => context is IEnumerable e
             ? GetTypedResultFromEnumerable(e, x => x
                 .Select(y => selectorExpression == null
@@ -73,11 +73,14 @@ public static class EnumerableExpression
                     : selectorExpression.Evaluate(y)))
                 .Transform(result => result.IsSuccessful()
                     ? aggregateDelegate.Invoke(result.Value!)
-                    : Result<object?>.FromExistingResult(result))
-            : GetInvalidResult(context);
+                    : Result<T>.FromExistingResult(result))
+            : GetInvalidResult<T>(context);
 
     public static Result<object?> GetInvalidResult(object? context)
-        => context.Transform(x => Result<object?>.Invalid(x == null
+        => GetInvalidResult<object?>(context);
+
+    public static Result<T> GetInvalidResult<T>(object? context)
+        => context.Transform(x => Result<T>.Invalid(x == null
                 ? "Context cannot be empty"
                 : "Context is not of type enumerable"));
     
@@ -159,29 +162,29 @@ public static class EnumerableExpression
             });
 
 #pragma warning disable S107 // Methods should not have too many parameters
-    private static Result<object?> GetScalarValue(object? context,
-                                                  Expression? predicate,
-                                                  Func<IEnumerable<object?>, Result<object?>> delegateWithoutPredicate,
-                                                  Func<IEnumerable<ItemResult>, Result<object?>>? delegateWithPredicate,
-                                                  Func<object?, Result<object?>>? defaultValueDelegateWithoutPredicate,
-                                                  Func<object?, Result<object?>>? defaultValueDelegateWithPredicate,
-                                                  Func<IEnumerable<object?>, Result<IEnumerable<object?>>>? selectorDelegate = null,
-                                                  bool predicateIsRequired = false)
+    private static Result<T> GetScalarValue<T>(object? context,
+                                               Expression? predicate,
+                                               Func<IEnumerable<object?>, Result<T>> delegateWithoutPredicate,
+                                               Func<IEnumerable<ItemResult>, Result<T>>? delegateWithPredicate,
+                                               Func<object?, Result<T>>? defaultValueDelegateWithoutPredicate,
+                                               Func<object?, Result<T>>? defaultValueDelegateWithPredicate,
+                                               Func<IEnumerable<object?>, Result<IEnumerable<object?>>>? selectorDelegate = null,
+                                               bool predicateIsRequired = false)
 #pragma warning restore S107 // Methods should not have too many parameters
     {
         if (context == null)
         {
-            return Result<object?>.Invalid("Context cannot be empty");
+            return Result<T>.Invalid("Context cannot be empty");
         }
         
         if (context is not IEnumerable e)
         {
-            return Result<object?>.Invalid("Context is not of type enumerable");
+            return Result<T>.Invalid("Context is not of type enumerable");
         }
 
         if (predicateIsRequired && predicate == null)
         {
-            return Result<object?>.Invalid("Predicate is required");
+            return Result<T>.Invalid("Predicate is required");
         }
 
         if (selectorDelegate == null)
@@ -192,7 +195,7 @@ public static class EnumerableExpression
         var itemsResult = selectorDelegate.Invoke(e.OfType<object?>());
         if (!itemsResult.IsSuccessful())
         {
-            return Result<object?>.FromExistingResult(itemsResult);
+            return Result<T>.FromExistingResult(itemsResult);
         }
 
         if (predicate == null)
@@ -214,7 +217,7 @@ public static class EnumerableExpression
         if (results.Any(x => !x.Result.IsSuccessful()))
         {
             // Error in predicate evaluation
-            return Result<object?>.FromExistingResult(results.First(x => !x.Result.IsSuccessful()).Result);
+            return Result<T>.FromExistingResult(results.First(x => !x.Result.IsSuccessful()).Result);
         }
 
         if (!results.Any(x => x.Result.Value) && defaultValueDelegateWithPredicate != null)
@@ -223,6 +226,6 @@ public static class EnumerableExpression
         }
 
         return delegateWithPredicate?.Invoke(results)
-            ?? Result<object?>.Invalid("DelegateWithPredicate is required when predicate is filled");
+            ?? Result<T>.Invalid("DelegateWithPredicate is required when predicate is filled");
     }
 }

--- a/src/ExpressionFramework.Domain/EnumerableExpression.cs
+++ b/src/ExpressionFramework.Domain/EnumerableExpression.cs
@@ -211,7 +211,7 @@ public static class EnumerableExpression
         var results = itemsResult.Value.Select(x => new ItemResult
         (
             x,
-            predicate.Evaluate(x).TryCast<bool>("Predicate did not return a boolean value")
+            predicate.EvaluateTyped<bool>(x, "Predicate did not return a boolean value")
         )).TakeWhileWithFirstNonMatching(x => x.Result.IsSuccessful());
 
         if (results.Any(x => !x.Result.IsSuccessful()))

--- a/src/ExpressionFramework.Domain/EnumerableOfExpressionExtensions.cs
+++ b/src/ExpressionFramework.Domain/EnumerableOfExpressionExtensions.cs
@@ -7,4 +7,10 @@ public static class EnumerableOfExpressionExtensions
             .Select(x => x.Evaluate(context))
             .TakeWhileWithFirstNonMatching(x => x.IsSuccessful())
             .ToArray();
+
+    public static Result<T>[] EvaluateTypedUntilFirstError<T>(this IEnumerable<Expression> expressions, object? context, string? errorMessage = null)
+        => expressions
+            .Select(x => x.EvaluateTyped<T>(context, errorMessage))
+            .TakeWhileWithFirstNonMatching(x => x.IsSuccessful())
+            .ToArray();
 }

--- a/src/ExpressionFramework.Domain/ExpressionExtensions.cs
+++ b/src/ExpressionFramework.Domain/ExpressionExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace ExpressionFramework.Domain;
+
+public static class ExpressionExtensions
+{
+    public static Result<T> EvaluateTyped<T>(this Expression instance, object? context, string? errorMessage = null)
+    {
+        if (instance is ITypedExpression<T> typedExpression)
+        {
+            return typedExpression.EvaluateTyped(context);
+        }
+
+        return instance.Evaluate(context).TryCast<T>(errorMessage);
+    }
+}

--- a/src/ExpressionFramework.Domain/Expressions/AllExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/AllExpression.cs
@@ -1,7 +1,7 @@
 ﻿namespace ExpressionFramework.Domain.Expressions;
 
 [DynamicDescriptor(typeof(AllExpression))]
-public partial record AllExpression
+public partial record AllExpression : ITypedExpression<bool>
 {
     public override Result<object?> Evaluate(object? context)
         => EnumerableExpression.GetOptionalScalarValue
@@ -10,6 +10,16 @@ public partial record AllExpression
             PredicateExpression,
             null!, // you can't get here... predicate is always checked
             results => Result<object?>.Success(results.All(x => x.Result.Value)),
+            predicateIsRequired: true
+        );
+
+    public Result<bool> EvaluateTyped(object? context)
+        => EnumerableExpression.GetOptionalScalarValue
+        (
+            context,
+            PredicateExpression,
+            null!, // you can't get here... predicate is always checked
+            results => Result<bool>.Success(results.All(x => x.Result.Value)),
             predicateIsRequired: true
         );
 

--- a/src/ExpressionFramework.Domain/Expressions/AnyExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/AnyExpression.cs
@@ -1,7 +1,7 @@
 ﻿namespace ExpressionFramework.Domain.Expressions;
 
 [DynamicDescriptor(typeof(AnyExpression))]
-public partial record AnyExpression
+public partial record AnyExpression : ITypedExpression<bool>
 {
     public override Result<object?> Evaluate(object? context)
         => EnumerableExpression.GetOptionalScalarValue
@@ -10,6 +10,15 @@ public partial record AnyExpression
             PredicateExpression,
             results => Result<object?>.Success(results.Any()),
             results => Result<object?>.Success(results.Any(x => x.Result.Value))
+        );
+
+    public Result<bool> EvaluateTyped(object? context)
+        => EnumerableExpression.GetOptionalScalarValue
+        (
+            context,
+            PredicateExpression,
+            results => Result<bool>.Success(results.Any()),
+            results => Result<bool>.Success(results.Any(x => x.Result.Value))
         );
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)

--- a/src/ExpressionFramework.Domain/Expressions/BooleanConstantExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/BooleanConstantExpression.cs
@@ -1,0 +1,16 @@
+﻿namespace ExpressionFramework.Domain.Expressions;
+
+[ExpressionDescription("Returns a boolean constant value")]
+[UsesContext(false)]
+[ParameterDescription(nameof(Value), "Value to use")]
+[ParameterRequired(nameof(Value), true)]
+[ReturnValue(ResultStatus.Ok, typeof(object), "The value that is supplied with the Value parameter", "This result will always be returned")]
+public partial record BooleanConstantExpression : ITypedExpression<bool>
+{
+    public override Result<object?> Evaluate(object? context)
+        => Result<object?>.Success(Value);
+
+    public Result<bool> EvaluateTyped(object? context)
+        => Result<bool>.Success(Value);
+}
+

--- a/src/ExpressionFramework.Domain/Expressions/CountExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/CountExpression.cs
@@ -1,7 +1,7 @@
 ﻿namespace ExpressionFramework.Domain.Expressions;
 
 [DynamicDescriptor(typeof(CountExpression))]
-public partial record CountExpression
+public partial record CountExpression : ITypedExpression<int>
 {
     public override Result<object?> Evaluate(object? context)
         => EnumerableExpression.GetOptionalScalarValue
@@ -10,6 +10,15 @@ public partial record CountExpression
             PredicateExpression,
             results => Result<object?>.Success(results.Count()),
             results => Result<object?>.Success(results.Count(x => x.Result.Value))
+        );
+
+    public Result<int> EvaluateTyped(object? context)
+        => EnumerableExpression.GetOptionalScalarValue
+        (
+            context,
+            PredicateExpression,
+            results => Result<int>.Success(results.Count()),
+            results => Result<int>.Success(results.Count(x => x.Result.Value))
         );
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)

--- a/src/ExpressionFramework.Domain/Expressions/ElementAtExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ElementAtExpression.cs
@@ -9,13 +9,11 @@ public partial record ElementAtExpression
             context,
             null,
             results => IndexExpression
-                .Evaluate(context)
-                .TryCast<int>("IndexExpression did not return an integer")
+                .EvaluateTyped<int>(context, "IndexExpression did not return an integer")
                 .Transform(indexResult => Result<object?>.Success(results.ElementAt(indexResult.Value))),
             selectorDelegate: items =>
                 IndexExpression
-                    .Evaluate(context)
-                    .TryCast<int>("IndexExpression did not return an integer")
+                    .EvaluateTyped<int>(context, "IndexExpression did not return an integer")
                     .Transform(indexResult => indexResult.IsSuccessful()
                         ? indexResult.Value.Transform(index => items.Count() >= index
                             ? Result<IEnumerable<object?>>.Success(items)

--- a/src/ExpressionFramework.Domain/Expressions/ElementAtOrDefaultExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ElementAtOrDefaultExpression.cs
@@ -9,8 +9,7 @@ public partial record ElementAtOrDefaultExpression
             context,
             null,
             results => IndexExpression
-                .Evaluate(context)
-                .TryCast<int>("IndexExpression did not return an integer")
+                .EvaluateTyped<int>(context, "IndexExpression did not return an integer")
                 .Transform(indexResult => indexResult.IsSuccessful()
                         ? indexResult.Value.Transform(index => results.Count() >= index
                             ? Result<object?>.Success(results.ElementAt(index))

--- a/src/ExpressionFramework.Domain/Expressions/EqualsExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/EqualsExpression.cs
@@ -10,7 +10,7 @@
 [ParameterDescription(nameof(SecondExpression), "Second expression")]
 [ParameterRequired(nameof(SecondExpression), true)]
 [ReturnValue(ResultStatus.Ok, typeof(bool), "true of false", "This result will always be returned")]
-public partial record EqualsExpression
+public partial record EqualsExpression : ITypedExpression<bool>
 {
     public override Result<object?> Evaluate(object? context)
     {
@@ -20,5 +20,15 @@ public partial record EqualsExpression
         return nonSuccessfulResult != null
             ? nonSuccessfulResult
             : Result<object?>.Success(EqualsOperator.IsValid(results[0], results[1]));
+    }
+
+    public Result<bool> EvaluateTyped(object? context)
+    {
+        var results = new[] { FirstExpression, SecondExpression }.EvaluateUntilFirstError(context);
+
+        var nonSuccessfulResult = results.FirstOrDefault(x => !x.IsSuccessful());
+        return nonSuccessfulResult != null
+            ? Result<bool>.FromExistingResult(nonSuccessfulResult)
+            : Result<bool>.Success(EqualsOperator.IsValid(results[0], results[1]));
     }
 }

--- a/src/ExpressionFramework.Domain/Expressions/FalseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/FalseExpression.cs
@@ -3,9 +3,12 @@
 [ExpressionDescription("Returns false")]
 [UsesContext(false)]
 [ReturnValue(ResultStatus.Ok, typeof(bool), "false", "This result will always be returned")]
-public partial record FalseExpression
+public partial record FalseExpression : ITypedExpression<bool>
 {
     public override Result<object?> Evaluate(object? context)
         => Result<object?>.Success(false);
+
+    public Result<bool> EvaluateTyped(object? context)
+        => Result<bool>.Success(false);
 }
 

--- a/src/ExpressionFramework.Domain/Expressions/Int32ConstantExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/Int32ConstantExpression.cs
@@ -1,0 +1,17 @@
+﻿namespace ExpressionFramework.Domain.Expressions
+{
+    [ExpressionDescription("Returns a constant integer value")]
+    [UsesContext(false)]
+    [ParameterDescription(nameof(Value), "Value to use")]
+    [ParameterRequired(nameof(Value), true)]
+    [ReturnValue(ResultStatus.Ok, typeof(object), "The value that is supplied with the Value parameter", "This result will always be returned")]
+    public partial record Int32ConstantExpression : ITypedExpression<int>
+    {
+        public override Result<object?> Evaluate(object? context)
+            => Result<object?>.Success(Value);
+
+        public Result<int> EvaluateTyped(object? context)
+            => Result<int>.Success(Value);
+    }
+}
+

--- a/src/ExpressionFramework.Domain/Expressions/LeftExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/LeftExpression.cs
@@ -9,29 +9,32 @@
 [ParameterRequired(nameof(LengthExpression), true)]
 [ReturnValue(ResultStatus.Ok, typeof(string), "The first characters of the context", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string, LengthExpression did not return an integer, Length must refer to a location within the string")]
-public partial record LeftExpression
+public partial record LeftExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
+        => EvaluateTyped(context).TryCast<object?>();
+
+    public Result<string> EvaluateTyped(object? context)
         => context is string s
             ? GetLeftValueFromString(s)
-            : Result<object?>.Invalid("Context must be of type string");
+            : Result<string>.Invalid("Context must be of type string");
 
-    private Result<object?> GetLeftValueFromString(string s)
+    private Result<string> GetLeftValueFromString(string s)
     {
         var lengthResult = LengthExpression.Evaluate(s);
         if (!lengthResult.IsSuccessful())
         {
-            return lengthResult;
+            return Result<string>.FromExistingResult(lengthResult);
         }
 
         if (lengthResult.Value is not int length)
         {
-            return Result<object?>.Invalid("LengthExpression did not return an integer");
+            return Result<string>.Invalid("LengthExpression did not return an integer");
         }
 
         return s.Length >= length
-            ? Result<object?>.Success(s.Substring(0, length))
-            : Result<object?>.Invalid("Length must refer to a location within the string");
+            ? Result<string>.Success(s.Substring(0, length))
+            : Result<string>.Invalid("Length must refer to a location within the string");
     }
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)

--- a/src/ExpressionFramework.Domain/Expressions/LeftExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/LeftExpression.cs
@@ -12,7 +12,7 @@
 public partial record LeftExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
-        => EvaluateTyped(context).TryCast<object?>();
+        => Result<object?>.FromExistingResult(EvaluateTyped(context), value => value);
 
     public Result<string> EvaluateTyped(object? context)
         => context is string s

--- a/src/ExpressionFramework.Domain/Expressions/NotExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/NotExpression.cs
@@ -7,11 +7,16 @@
 [ContextRequired(true)]
 [ReturnValue(ResultStatus.Ok, typeof(bool), "Inverted value of the boolean context value", "This result will be returned when the context is a boolean value")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type boolean")]
-public partial record NotExpression
+public partial record NotExpression : ITypedExpression<bool>
 {
     public override Result<object?> Evaluate(object? context)
         => context is bool b
             ? Result<object?>.Success(!b)
             : Result<object?>.Invalid("Context must be of type boolean");
+
+    public Result<bool> EvaluateTyped(object? context)
+        => context is bool b
+            ? Result<bool>.Success(!b)
+            : Result<bool>.Invalid("Context must be of type boolean");
 }
 

--- a/src/ExpressionFramework.Domain/Expressions/RightExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/RightExpression.cs
@@ -10,24 +10,27 @@
 [ParameterType(nameof(LengthExpression), typeof(int))]
 [ReturnValue(ResultStatus.Ok, typeof(string), "The last characters of the context", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string, LengthExpression did not return an integer, Length must refer to a location within the string")]
-public partial record RightExpression
+public partial record RightExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
+        => EvaluateTyped(context).TryCast<object?>();
+
+    public Result<string> EvaluateTyped(object? context)
         => context is string s
             ? GetRightValueFromString(s)
-            : Result<object?>.Invalid("Context must be of type string");
+            : Result<string>.Invalid("Context must be of type string");
 
-    private Result<object?> GetRightValueFromString(string s)
+    private Result<string> GetRightValueFromString(string s)
     {
         var lengthResult = LengthExpression.Evaluate(s).TryCast<int>("LengthExpression did not return an integer");
         if (!lengthResult.IsSuccessful())
         {
-            return Result<object?>.FromExistingResult(lengthResult);
+            return Result<string>.FromExistingResult(lengthResult);
         }
 
         return s.Length >= lengthResult.Value
-            ? Result<object?>.Success(s.Substring(s.Length - lengthResult.Value, lengthResult.Value))
-            : Result<object?>.Invalid("Length must refer to a location within the string");
+            ? Result<string>.Success(s.Substring(s.Length - lengthResult.Value, lengthResult.Value))
+            : Result<string>.Invalid("Length must refer to a location within the string");
     }
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)

--- a/src/ExpressionFramework.Domain/Expressions/RightExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/RightExpression.cs
@@ -22,7 +22,7 @@ public partial record RightExpression : ITypedExpression<string>
 
     private Result<string> GetRightValueFromString(string s)
     {
-        var lengthResult = LengthExpression.Evaluate(s).TryCast<int>("LengthExpression did not return an integer");
+        var lengthResult = LengthExpression.EvaluateTyped<int>(s, "LengthExpression did not return an integer");
         if (!lengthResult.IsSuccessful())
         {
             return Result<string>.FromExistingResult(lengthResult);

--- a/src/ExpressionFramework.Domain/Expressions/RightExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/RightExpression.cs
@@ -13,7 +13,7 @@
 public partial record RightExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
-        => EvaluateTyped(context).TryCast<object?>();
+        => Result<object?>.FromExistingResult(EvaluateTyped(context), value => value);
 
     public Result<string> EvaluateTyped(object? context)
         => context is string s

--- a/src/ExpressionFramework.Domain/Expressions/SequenceExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SequenceExpression.cs
@@ -1,0 +1,22 @@
+﻿namespace ExpressionFramework.Domain.Expressions;
+
+[ExpressionDescription("Returns all supplied expressions into a sequence (enumerable)")]
+[UsesContext(false)]
+[ParameterDescription(nameof(Expressions), "Expressions to put in a sequence (enumerable)")]
+[ParameterRequired(nameof(Expressions), true)]
+[ReturnValue(ResultStatus.Ok, typeof(object), "Enumerable with items", "This will be returned in case all expressions return Ok")]
+[ReturnValue(ResultStatus.Error, "Empty", "This status (or any other status not equal to Ok) will be returned in case any expression returns something else than Ok")]
+public partial record SequenceExpression
+{
+    public override Result<object?> Evaluate(object? context)
+    {
+        var values = Expressions.EvaluateUntilFirstError(context);
+        if (values.Any() && !values.Last().IsSuccessful())
+        {
+            return values.Last();
+        }
+
+        return Result<object?>.Success(values.Select(x => x.Value));
+    }
+}
+

--- a/src/ExpressionFramework.Domain/Expressions/SequenceExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SequenceExpression.cs
@@ -18,5 +18,16 @@ public partial record SequenceExpression
 
         return Result<object?>.Success(values.Select(x => x.Value));
     }
+
+    public Result<IEnumerable<object?>> EvaluateTyped(object? context)
+    {
+        var values = Expressions.EvaluateUntilFirstError(context);
+        if (values.Any() && !values.Last().IsSuccessful())
+        {
+            return Result<IEnumerable<object?>>.FromExistingResult(values.Last());
+        }
+
+        return Result<IEnumerable<object?>>.Success(values.Select(x => x.Value));
+    }
 }
 

--- a/src/ExpressionFramework.Domain/Expressions/SingleExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SingleExpression.cs
@@ -10,7 +10,7 @@ public partial record SingleExpression
             PredicateExpression,
             results => Result<object?>.Success(results.Single()),
             results => Result<object?>.Success(results.Single(x => x.Result.Value).Item),
-            items => items.Count(x => PredicateExpression == null || PredicateExpression.Evaluate(x).TryCast<bool>("Predicate did not return a boolean value").Value) > 1
+            items => items.Count(x => PredicateExpression == null || PredicateExpression.EvaluateTyped<bool>(x, "Predicate did not return a boolean value").Value) > 1
                 ? Result<IEnumerable<object?>>.Invalid("Sequence contains more than one element")
                 : Result<IEnumerable<object?>>.Success(items)
         );

--- a/src/ExpressionFramework.Domain/Expressions/SingleOrDefaultExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SingleOrDefaultExpression.cs
@@ -11,7 +11,7 @@ public partial record SingleOrDefaultExpression
             results => Result<object?>.Success(results.Single()),
             results => Result<object?>.Success(results.Single(x => x.Result.Value).Item),
             context => EnumerableExpression.GetDefaultValue(DefaultExpression, context),
-            items => items.Count(x => PredicateExpression == null || PredicateExpression.Evaluate(x).TryCast<bool>("Predicate did not return a boolean value").Value) > 1
+            items => items.Count(x => PredicateExpression == null || PredicateExpression.EvaluateTyped<bool>(x, "Predicate did not return a boolean value").Value) > 1
                 ? Result<IEnumerable<object?>>.Invalid("Sequence contains more than one element")
                 : Result<IEnumerable<object?>>.Success(items)
         );

--- a/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
@@ -25,17 +25,13 @@ public partial record StringConcatenateExpression : ITypedExpression<string>
             return Result<string>.FromExistingResult(values.Last());
         }
 
-        var strings = values
-            .TakeWhileWithFirstNonMatching(x => x.IsSuccessful())
-            .ToArray();
-
-        var unsuccessfulResult = strings.FirstOrDefault(x => !x.IsSuccessful());
+        var unsuccessfulResult = values.FirstOrDefault(x => !x.IsSuccessful());
         if (unsuccessfulResult != null)
         {
             return Result<string>.FromExistingResult(unsuccessfulResult);
         }
 
-        return Result<string>.Success(string.Concat(strings.Select(x => x.Value)));
+        return Result<string>.Success(string.Concat(values.Select(x => x.Value)));
     }
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)

--- a/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
@@ -10,7 +10,7 @@
 public partial record StringConcatenateExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
-        => EvaluateTyped(context).TryCast<object?>();
+        => Result<object?>.FromExistingResult(EvaluateTyped(context), value => value);
 
     public Result<string> EvaluateTyped(object? context)
     {

--- a/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
@@ -14,7 +14,7 @@ public partial record StringConcatenateExpression : ITypedExpression<string>
 
     public Result<string> EvaluateTyped(object? context)
     {
-        var values = Expressions.EvaluateUntilFirstError(context);
+        var values = Expressions.EvaluateTypedUntilFirstError<string>(context, "Expression must be of type string");
         if (!values.Any())
         {
             return Result<string>.Invalid("At least one expression is required");
@@ -25,7 +25,7 @@ public partial record StringConcatenateExpression : ITypedExpression<string>
             return Result<string>.FromExistingResult(values.Last());
         }
 
-        var strings = values.Select(x => x.TryCast<string>("Expression must be of type string"))
+        var strings = values
             .TakeWhileWithFirstNonMatching(x => x.IsSuccessful())
             .ToArray();
 

--- a/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
@@ -25,12 +25,6 @@ public partial record StringConcatenateExpression : ITypedExpression<string>
             return Result<string>.FromExistingResult(values.Last());
         }
 
-        var unsuccessfulResult = values.FirstOrDefault(x => !x.IsSuccessful());
-        if (unsuccessfulResult != null)
-        {
-            return Result<string>.FromExistingResult(unsuccessfulResult);
-        }
-
         return Result<string>.Success(string.Concat(values.Select(x => x.Value)));
     }
 

--- a/src/ExpressionFramework.Domain/Expressions/StringConstantExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringConstantExpression.cs
@@ -1,0 +1,16 @@
+﻿namespace ExpressionFramework.Domain.Expressions;
+
+[ExpressionDescription("Returns a constant value")]
+[UsesContext(false)]
+[ParameterDescription(nameof(Value), "Value to use")]
+[ParameterRequired(nameof(Value), true)]
+[ReturnValue(ResultStatus.Ok, typeof(object), "The value that is supplied with the Value parameter", "This result will always be returned")]
+public partial record StringConstantExpression : ITypedExpression<string>
+{
+    public override Result<object?> Evaluate(object? context)
+        => Result<object?>.Success(Value);
+
+    public Result<string> EvaluateTyped(object? context)
+        => Result<string>.Success(Value);
+}
+

--- a/src/ExpressionFramework.Domain/Expressions/StringLengthExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringLengthExpression.cs
@@ -7,12 +7,17 @@
 [ContextType(typeof(string))]
 [ReturnValue(ResultStatus.Ok, typeof(int), "The length of the (string) context", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string")]
-public partial record StringLengthExpression
+public partial record StringLengthExpression : ITypedExpression<int>
 {
     public override Result<object?> Evaluate(object? context)
         => context is string s
             ? Result<object?>.Success(s.Length)
             : Result<object?>.Invalid("Context must be of type string");
+
+    public Result<int> EvaluateTyped(object? context)
+        => context is string s
+            ? Result<int>.Success(s.Length)
+            : Result<int>.Invalid("Context must be of type string");
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)
         => StringExpression.ValidateContext(context);

--- a/src/ExpressionFramework.Domain/Expressions/SubstringExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SubstringExpression.cs
@@ -14,7 +14,7 @@
 public partial record SubstringExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
-        => EvaluateTyped(context).TryCast<object?>();
+        => Result<object?>.FromExistingResult(EvaluateTyped(context), value => value);
 
     public Result<string> EvaluateTyped(object? context)
         => context is string s

--- a/src/ExpressionFramework.Domain/Expressions/ToLowerCaseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ToLowerCaseExpression.cs
@@ -7,12 +7,17 @@
 [ContextType(typeof(string))]
 [ReturnValue(ResultStatus.Ok, typeof(string), "The value of the context converted to lower case", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string")]
-public partial record ToLowerCaseExpression
+public partial record ToLowerCaseExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
         => context is string s
             ? Result<object?>.Success(s.ToLower())
             : Result<object?>.Invalid("Context must be of type string");
+
+    public Result<string> EvaluateTyped(object? context)
+        => context is string s
+            ? Result<string>.Success(s.ToLower())
+            : Result<string>.Invalid("Context must be of type string");
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)
         => StringExpression.ValidateContext(context);

--- a/src/ExpressionFramework.Domain/Expressions/ToPascalCaseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ToPascalCaseExpression.cs
@@ -22,9 +22,9 @@ public partial record ToPascalCaseExpression : ITypedExpression<string>
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)
         => StringExpression.ValidateContext(context);
 
-    private string? ToPascalCase(string value)
+    private string ToPascalCase(string value)
     {
-        if (!string.IsNullOrEmpty(value))
+        if (value.Length > 0)
         {
             return value.Substring(0, 1).ToLowerInvariant() + value.Substring(1);
         }

--- a/src/ExpressionFramework.Domain/Expressions/ToPascalCaseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ToPascalCaseExpression.cs
@@ -7,12 +7,17 @@
 [ContextType(typeof(string))]
 [ReturnValue(ResultStatus.Ok, typeof(string), "The value of the context converted to pascal case", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string")]
-public partial record ToPascalCaseExpression
+public partial record ToPascalCaseExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
         => context is string s
             ? Result<object?>.Success(ToPascalCase(s))
             : Result<object?>.Invalid("Context must be of type string");
+
+    public Result<string> EvaluateTyped(object? context)
+        => context is string s
+            ? Result<string>.Success(ToPascalCase(s))
+            : Result<string>.Invalid("Context must be of type string");
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)
         => StringExpression.ValidateContext(context);

--- a/src/ExpressionFramework.Domain/Expressions/ToUpperCaseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ToUpperCaseExpression.cs
@@ -7,12 +7,17 @@
 [ContextType(typeof(string))]
 [ReturnValue(ResultStatus.Ok, typeof(string), "The value of the context converted to upper case", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string")]
-public partial record ToUpperCaseExpression
+public partial record ToUpperCaseExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
         => context is string s
             ? Result<object?>.Success(s.ToUpper())
             : Result<object?>.Invalid("Context must be of type string");
+
+    public Result<string> EvaluateTyped(object? context)
+        => context is string s
+            ? Result<string>.Success(s.ToUpper())
+            : Result<string>.Invalid("Context must be of type string");
 
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)
         => StringExpression.ValidateContext(context);

--- a/src/ExpressionFramework.Domain/Expressions/TrimEndExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TrimEndExpression.cs
@@ -9,18 +9,26 @@
 [ParameterRequired(nameof(TrimChars), false)]
 [ReturnValue(ResultStatus.Ok, typeof(string), "The trim end value of the context", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string")]
-public partial record TrimEndExpression
+public partial record TrimEndExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
         => context is string s
             ? Result<object?>.Success(TrimEnd(s))
             : Result<object?>.Invalid("Context must be of type string");
 
+    public Result<string> EvaluateTyped(object? context)
+        => context is string s
+            ? Result<string>.Success(TrimEnd(s))
+            : Result<string>.Invalid("Context must be of type string");
+
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)
         => StringExpression.ValidateContext(context);
 
     public TrimEndExpression() : this(default(IEnumerable<char>)) { }
 
-    private string TrimEnd(string s) => TrimChars == null ? s.TrimEnd() : s.TrimEnd(TrimChars.ToArray());
+    private string TrimEnd(string s)
+        => TrimChars == null
+            ? s.TrimEnd()
+            : s.TrimEnd(TrimChars.ToArray());
 }
 

--- a/src/ExpressionFramework.Domain/Expressions/TrimExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TrimExpression.cs
@@ -9,18 +9,26 @@
 [ParameterRequired(nameof(TrimChars), false)]
 [ReturnValue(ResultStatus.Ok, typeof(string), "The trim start and end value of the context", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string")]
-public partial record TrimExpression
+public partial record TrimExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
         => context is string s
             ? Result<object?>.Success(Trim(s))
             : Result<object?>.Invalid("Context must be of type string");
 
+    public Result<string> EvaluateTyped(object? context)
+        => context is string s
+            ? Result<string>.Success(Trim(s))
+            : Result<string>.Invalid("Context must be of type string");
+
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)
         => StringExpression.ValidateContext(context);
 
     public TrimExpression() : this(default(IEnumerable<char>)) { }
 
-    private string Trim(string s) => TrimChars == null ? s.Trim() : s.Trim(TrimChars.ToArray());
+    private string Trim(string s)
+        => TrimChars == null
+            ? s.Trim()
+            : s.Trim(TrimChars.ToArray());
 }
 

--- a/src/ExpressionFramework.Domain/Expressions/TrimStartExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TrimStartExpression.cs
@@ -9,18 +9,26 @@
 [ParameterRequired(nameof(TrimChars), false)]
 [ReturnValue(ResultStatus.Ok, typeof(string), "The trim start value of the context", "This result will be returned when the context is of type string")]
 [ReturnValue(ResultStatus.Invalid, "Empty", "Context must be of type string")]
-public partial record TrimStartExpression
+public partial record TrimStartExpression : ITypedExpression<string>
 {
     public override Result<object?> Evaluate(object? context)
         => context is string s
             ? Result<object?>.Success(TrimStart(s))
             : Result<object?>.Invalid("Context must be of type string");
 
+    public Result<string> EvaluateTyped(object? context)
+        => context is string s
+            ? Result<string>.Success(TrimStart(s))
+            : Result<string>.Invalid("Context must be of type string");
+
     public override IEnumerable<ValidationResult> ValidateContext(object? context, ValidationContext validationContext)
         => StringExpression.ValidateContext(context);
 
     public TrimStartExpression() : this(default(IEnumerable<char>)) { }
 
-    private string TrimStart(string s) => TrimChars == null ? s.TrimStart() : s.TrimStart(TrimChars.ToArray());
+    private string TrimStart(string s)
+        => TrimChars == null
+            ? s.TrimStart()
+            : s.TrimStart(TrimChars.ToArray());
 }
 

--- a/src/ExpressionFramework.Domain/Expressions/TrueExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TrueExpression.cs
@@ -3,9 +3,12 @@
 [ExpressionDescription("Returns true")]
 [UsesContext(false)]
 [ReturnValue(ResultStatus.Ok, typeof(bool), "true", "This result will always be returned")]
-public partial record TrueExpression
+public partial record TrueExpression : ITypedExpression<bool>
 {
     public override Result<object?> Evaluate(object? context)
         => Result<object?>.Success(true);
+
+    public Result<bool> EvaluateTyped(object? context)
+        => Result<bool>.Success(true);
 }
 

--- a/src/ExpressionFramework.Domain/ITypedExpression.cs
+++ b/src/ExpressionFramework.Domain/ITypedExpression.cs
@@ -1,0 +1,6 @@
+﻿namespace ExpressionFramework.Domain;
+
+public interface ITypedExpression<T>
+{
+    Result<T> EvaluateTyped(object? context);
+}


### PR DESCRIPTION
- Added support for typed expressions. Out of the box you get typed expressions for bool, int and stirng
- Added SequenceExpression
- Updated existing expressions to implement ITypedExpression for int, bool, string and IEnumerable<object?>
- Did some refactoring to simplify getting typed values from an expression, using EvaluateTyped<T> that first tries ITypedExpression<T>, or TryCast<T> in case typed execution is not supported