### PR TITLE
Refactor optional validation

### DIFF
--- a/ExpressionFramework.sln
+++ b/ExpressionFramework.sln
@@ -16,7 +16,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Domain"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Domain.Tests", "src\ExpressionFramework.Domain.Tests\ExpressionFramework.Domain.Tests.csproj", "{2649118A-C218-4CC6-9A3D-A00A2730BE24}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpressionFramework.Domain.Builders", "src\ExpressionFramework.Domain.Builders\ExpressionFramework.Domain.Builders.csproj", "{7537166A-6351-4CFC-A20B-C94AA127248D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Domain.Builders", "src\ExpressionFramework.Domain.Builders\ExpressionFramework.Domain.Builders.csproj", "{7537166A-6351-4CFC-A20B-C94AA127248D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModelFramework.CodeGeneration", "..\ModelFramework\src\ModelFramework.CodeGeneration\ModelFramework.CodeGeneration.csproj", "{01B1C8D5-1908-4EFF-85C8-445737417F39}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModelFramework.Objects", "..\ModelFramework\src\ModelFramework.Objects\ModelFramework.Objects.csproj", "{27538990-10A7-4B59-93BD-953E797249CA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,6 +44,14 @@ Global
 		{7537166A-6351-4CFC-A20B-C94AA127248D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7537166A-6351-4CFC-A20B-C94AA127248D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7537166A-6351-4CFC-A20B-C94AA127248D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01B1C8D5-1908-4EFF-85C8-445737417F39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01B1C8D5-1908-4EFF-85C8-445737417F39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01B1C8D5-1908-4EFF-85C8-445737417F39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01B1C8D5-1908-4EFF-85C8-445737417F39}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27538990-10A7-4B59-93BD-953E797249CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27538990-10A7-4B59-93BD-953E797249CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27538990-10A7-4B59-93BD-953E797249CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27538990-10A7-4B59-93BD-953E797249CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ExpressionFramework.sln
+++ b/ExpressionFramework.sln
@@ -18,10 +18,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Domain.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Domain.Builders", "src\ExpressionFramework.Domain.Builders\ExpressionFramework.Domain.Builders.csproj", "{7537166A-6351-4CFC-A20B-C94AA127248D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModelFramework.CodeGeneration", "..\ModelFramework\src\ModelFramework.CodeGeneration\ModelFramework.CodeGeneration.csproj", "{01B1C8D5-1908-4EFF-85C8-445737417F39}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModelFramework.Objects", "..\ModelFramework\src\ModelFramework.Objects\ModelFramework.Objects.csproj", "{27538990-10A7-4B59-93BD-953E797249CA}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,14 +40,6 @@ Global
 		{7537166A-6351-4CFC-A20B-C94AA127248D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7537166A-6351-4CFC-A20B-C94AA127248D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7537166A-6351-4CFC-A20B-C94AA127248D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{01B1C8D5-1908-4EFF-85C8-445737417F39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{01B1C8D5-1908-4EFF-85C8-445737417F39}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{01B1C8D5-1908-4EFF-85C8-445737417F39}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{01B1C8D5-1908-4EFF-85C8-445737417F39}.Release|Any CPU.Build.0 = Release|Any CPU
-		{27538990-10A7-4B59-93BD-953E797249CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{27538990-10A7-4B59-93BD-953E797249CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{27538990-10A7-4B59-93BD-953E797249CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{27538990-10A7-4B59-93BD-953E797249CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/AbstractEntities.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/AbstractEntities.cs
@@ -9,6 +9,8 @@ public class AbstractEntities : ExpressionFrameworkCSharpClassBase
     protected override bool EnableEntityInheritance => true;
     protected override bool EnableBuilderInhericance => true;
 
+    protected override ArgumentValidationType ValidateArgumentsInConstructor => ArgumentValidationType.Never; // there are no properties in abstract base types (Aggregators, Evaluatables, Expressions and Operators), so this is not necessary
+
     public override object CreateModel()
         => GetImmutableClasses(GetAbstractModels(), "ExpressionFramework.Domain");
 }

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Aggregators.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Aggregators.cs
@@ -23,7 +23,7 @@ public class Aggregators : ExpressionFrameworkCSharpClassBase
                     .AddParameters(new ParameterBuilder().WithName("context").WithType(typeof(object)).WithIsNullable())
                     .AddParameters(new ParameterBuilder().WithName("secondExpression").WithTypeName("ExpressionFramework.Domain.Expression"))
                     .WithTypeName($"{typeof(Result<>).WithoutGenerics()}<{typeof(object).FullName}?>")
-                    .AddLiteralCodeStatements("throw new NotImplementedException();")
+                    .AddNotImplementedException()
                 )
                 .Build());
 

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Evaluatables.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Evaluatables.cs
@@ -22,7 +22,7 @@ public class Evaluatables : ExpressionFrameworkCSharpClassBase
                     .WithOverride()
                     .AddParameters(new ParameterBuilder().WithName("context").WithType(typeof(object)).WithIsNullable())
                     .WithType(typeof(Result<bool>))
-                    .AddLiteralCodeStatements("throw new NotImplementedException();")
+                    .AddNotImplementedException()
                 )
                 .Build());
 }

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Expressions.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Expressions.cs
@@ -22,7 +22,7 @@ public class Expressions : ExpressionFrameworkCSharpClassBase
                     .WithOverride()
                     .AddParameters(new ParameterBuilder().WithName("context").WithType(typeof(object)).WithIsNullable())
                     .WithTypeName($"{typeof(Result<>).WithoutGenerics()}<{typeof(object).FullName}?>")
-                    .AddLiteralCodeStatements("throw new NotImplementedException();")
+                    .AddNotImplementedException()
                 )
                 .AddGenericTypeArguments(x.GenericTypeArguments)
                 .AddGenericTypeArgumentConstraints(x.GenericTypeArgumentConstraints)

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Operators.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Operators.cs
@@ -27,7 +27,7 @@ public class Operators : ExpressionFrameworkCSharpClassBase
                         new ParameterBuilder().WithName("rightValue").WithType(typeof(object)).WithIsNullable()
                     )
                     .WithType(typeof(Result<bool>))
-                    .AddLiteralCodeStatements("throw new NotImplementedException();")
+                    .AddNotImplementedException()
                 )
                 .Build());
 }

--- a/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
+++ b/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
@@ -14,6 +14,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\ModelFramework\src\ModelFramework.CodeGeneration\ModelFramework.CodeGeneration.csproj" />
+      <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.40" />
     </ItemGroup>
 </Project>

--- a/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
+++ b/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
@@ -14,6 +14,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.39" />
+      <ProjectReference Include="..\..\..\ModelFramework\src\ModelFramework.CodeGeneration\ModelFramework.CodeGeneration.csproj" />
     </ItemGroup>
 </Project>

--- a/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/ComposableEvaluatableTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/ComposableEvaluatableTests.cs
@@ -6,7 +6,7 @@ public class ComposableEvaluatableTests
     public void Evaluate_Works_Correctly_On_Equals_With_Sequences()
     {
         // Arrange
-        var condition = new ComposableEvaluatable
+        var evaluatable = new ComposableEvaluatable
         (
             new ConstantExpression(new ReadOnlyValueCollection<string>(new[] { "1", "2", "3" })),
             new EqualsOperator(),
@@ -14,7 +14,7 @@ public class ComposableEvaluatableTests
         );
 
         // Act
-        var actual = Evaluate(new[] { condition });
+        var actual = Evaluate(new[] { evaluatable });
 
         // Assert
         actual.GetValueOrThrow().Should().BeTrue();
@@ -24,7 +24,7 @@ public class ComposableEvaluatableTests
     public void Evaluate_Works_Correctly_On_Contains_With_Sequence_Of_Strings()
     {
         // Arrange
-        var condition = new ComposableEvaluatable
+        var evaluatable = new ComposableEvaluatable
         (
             new ConstantExpression(new[] { "1", "2", "3" }),
             new EnumerableContainsOperator(),
@@ -32,7 +32,7 @@ public class ComposableEvaluatableTests
         );
 
         // Act
-        var actual = Evaluate(new[] { condition });
+        var actual = Evaluate(new[] { evaluatable });
 
 
         // Assert
@@ -43,7 +43,7 @@ public class ComposableEvaluatableTests
     public void Evaluate_Returns_Error_When_Condition_Evaluation_Fails_On_Non_Grouped_Conditions()
     {
         // Arrange
-        var condition = new ComposableEvaluatable
+        var evaluatable = new ComposableEvaluatable
         (
             new ConstantExpression(new[] { "1", "2", "3" }),
             new EnumerableContainsOperator(),
@@ -51,7 +51,7 @@ public class ComposableEvaluatableTests
         );
 
         // Act
-        var actual = Evaluate(new[] { condition });
+        var actual = Evaluate(new[] { evaluatable });
 
 
         // Assert
@@ -63,7 +63,7 @@ public class ComposableEvaluatableTests
     public void Evaluate_Returns_Error_When_Condition_Evaluation_Fails_On_Grouped_Conditions()
     {
         // Arrange
-        var condition = new ComposableEvaluatable
+        var evaluatable = new ComposableEvaluatable
         (
             true,
             true,
@@ -74,7 +74,7 @@ public class ComposableEvaluatableTests
         );
 
         // Act
-        var actual = Evaluate(new[] { condition });
+        var actual = Evaluate(new[] { evaluatable });
 
 
         // Assert
@@ -86,13 +86,13 @@ public class ComposableEvaluatableTests
     public void Can_Evaluate_Multiple_Conditions_With_And_Combination()
     {
         // Arrange
-        var condition1 = new ComposableEvaluatable
+        var evaluatable1 = new ComposableEvaluatable
         (
             new ConstantExpression("12345"),
             new EqualsOperator(),
             new ConstantExpression("12345")
         );
-        var condition2 = new ComposableEvaluatable
+        var evaluatable2 = new ComposableEvaluatable
         (
             Combination.And,
             new ConstantExpression("54321"),
@@ -101,7 +101,7 @@ public class ComposableEvaluatableTests
         );
 
         // Act
-        var actual = Evaluate(new[] { condition1, condition2 });
+        var actual = Evaluate(new[] { evaluatable1, evaluatable2 });
 
         // Assert
         actual.GetValueOrThrow().Should().BeTrue();
@@ -111,13 +111,13 @@ public class ComposableEvaluatableTests
     public void Can_Evaluate_Multiple_Conditions_With_Or_Combination()
     {
         // Arrange
-        var condition1 = new ComposableEvaluatable
+        var evaluatable1 = new ComposableEvaluatable
         (
             new ConstantExpression("12345"),
             new EqualsOperator(),
             new ConstantExpression("12345")
         );
-        var condition2 = new ComposableEvaluatable
+        var evaluatable2 = new ComposableEvaluatable
         (
             Combination.Or,
             new ConstantExpression("54321"),
@@ -126,7 +126,7 @@ public class ComposableEvaluatableTests
         );
 
         // Act
-        var actual = Evaluate(new[] { condition1, condition2 });
+        var actual = Evaluate(new[] { evaluatable1, evaluatable2 });
 
         // Assert
         actual.GetValueOrThrow().Should().BeTrue();
@@ -137,13 +137,13 @@ public class ComposableEvaluatableTests
     {
         // Arrange
         //This translates to: True&(False|True) -> True
-        var condition1 = new ComposableEvaluatable
+        var evaluatable1 = new ComposableEvaluatable
         (
             new ConstantExpression("12345"),
             new EqualsOperator(),
             new ConstantExpression("12345")
         );
-        var condition2 = new ComposableEvaluatable
+        var evaluatable2 = new ComposableEvaluatable
         (
             startGroup: true,
             endGroup: false,
@@ -152,7 +152,7 @@ public class ComposableEvaluatableTests
             new EqualsOperator(),
             new ConstantExpression("wrong")
         );
-        var condition3 = new ComposableEvaluatable
+        var evaluatable3 = new ComposableEvaluatable
         (
             startGroup: false,
             endGroup: true,
@@ -163,7 +163,7 @@ public class ComposableEvaluatableTests
         );
 
         // Act
-        var actual = Evaluate(new[] { condition1, condition2, condition3 });
+        var actual = Evaluate(new[] { evaluatable1, evaluatable2, evaluatable3 });
 
         // Assert
         actual.GetValueOrThrow().Should().BeTrue();
@@ -174,13 +174,13 @@ public class ComposableEvaluatableTests
     {
         // Arrange
         //This translates to: False|(True&True) -> True
-        var condition1 = new ComposableEvaluatable
+        var evaluatable1 = new ComposableEvaluatable
         (
             new ConstantExpression("12345"),
             new EqualsOperator(),
             new ConstantExpression("wrong")
         );
-        var condition2 = new ComposableEvaluatable
+        var evaluatable2 = new ComposableEvaluatable
         (
             startGroup: true,
             endGroup: false,
@@ -189,7 +189,7 @@ public class ComposableEvaluatableTests
             new EqualsOperator(),
             new ConstantExpression("54321")
         );
-        var condition3 = new ComposableEvaluatable
+        var evaluatable3 = new ComposableEvaluatable
         (
             startGroup: false,
             endGroup: true,
@@ -200,7 +200,7 @@ public class ComposableEvaluatableTests
         );
 
         // Act
-        var actual = Evaluate(new[] { condition1, condition2, condition3 });
+        var actual = Evaluate(new[] { evaluatable1, evaluatable2, evaluatable3 });
 
         // Assert
         actual.GetValueOrThrow().Should().BeTrue();
@@ -220,6 +220,24 @@ public class ComposableEvaluatableTests
         result.Name.Should().Be(nameof(ComposableEvaluatable));
         result.Parameters.Should().HaveCount(6);
         result.ReturnValues.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var evaluatable = new ComposableEvaluatableBase
+        (
+            false,
+            false,
+            Combination.And,
+            new ConstantExpression(new ReadOnlyValueCollection<string>(new[] { "1", "2", "3" })),
+            new EqualsOperator(),
+            new ConstantExpression(new ReadOnlyValueCollection<string>(new[] { "1", "2", "3" }))
+        );
+
+        // Act & Assert
+        evaluatable.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
     }
 
     private static Result<bool> Evaluate(IEnumerable<ComposableEvaluatable> conditions)

--- a/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/ComposedEvaluatableTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/ComposedEvaluatableTests.cs
@@ -68,6 +68,16 @@ public class ComposedEvaluatableTests
         result.ReturnValues.Should().ContainSingle();
     }
 
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var evaluatable = new ComposedEvaluatableBase(Enumerable.Empty<ComposableEvaluatable>());
+
+        // Act & Assert
+        evaluatable.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
     private static ComposableEvaluatableBuilder CreateEvaluatableBuilder()
         => new ComposableEvaluatableBuilder()
             .WithLeftExpression(new EmptyExpressionBuilder())

--- a/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/ConstantEvaluatableTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/ConstantEvaluatableTests.cs
@@ -19,6 +19,16 @@ public class ConstantEvaluatableTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var evaluatable = new ConstantEvaluatableBase(false);
+
+        // Act & Assert
+        evaluatable.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Get_Returns_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/DelegateEvaluatableTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/DelegateEvaluatableTests.cs
@@ -19,6 +19,16 @@ public class DelegateEvaluatableTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var evaluatable = new DelegateEvaluatableBase(() => false);
+
+        // Act & Assert
+        evaluatable.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Get_Returns_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/SingleEvaluatableTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Evaluatables/SingleEvaluatableTests.cs
@@ -3,6 +3,21 @@
 public class SingleEvaluatableTests
 {
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var evaluatable = new SingleEvaluatableBase
+        (
+            new ConstantExpression(new ReadOnlyValueCollection<string>(new[] { "1", "2", "3" })),
+            new EqualsOperator(),
+            new ConstantExpression(new ReadOnlyValueCollection<string>(new[] { "1", "2", "3" }))
+        );
+
+        // Act & Assert
+        evaluatable.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AggregateExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AggregateExpressionTests.cs
@@ -59,6 +59,16 @@ public class AggregateExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new AggregateExpressionBase(Enumerable.Empty<Expression>(), new AddAggregator());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AllExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AllExpressionTests.cs
@@ -227,6 +227,16 @@ public class AllExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new AllExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AndExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AndExpressionTests.cs
@@ -87,6 +87,16 @@ public class AndExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new AndExpressionBase(new TrueExpression(), new TrueExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AnyExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/AnyExpressionTests.cs
@@ -255,6 +255,16 @@ public class AnyExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new AnyExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ChainedExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ChainedExpressionTests.cs
@@ -57,6 +57,16 @@ public class ChainedExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ChainedExpressionBase(Enumerable.Empty<Expression>());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/CompoundExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/CompoundExpressionTests.cs
@@ -17,6 +17,16 @@ public class CompoundExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new CompoundExpressionBase(new EmptyExpression(), new EmptyExpression(), new AddAggregator());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ConstantExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ConstantExpressionTests.cs
@@ -3,6 +3,16 @@
 public class ConstantExpressionTests
 {
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ConstantExpressionBase(null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ContextExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ContextExpressionTests.cs
@@ -3,6 +3,16 @@
 public class ContextExpressionTests
 {
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ContextExpressionBase();
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/CountExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/CountExpressionTests.cs
@@ -255,6 +255,16 @@ public class CountExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new CountExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/DelegateExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/DelegateExpressionTests.cs
@@ -17,6 +17,16 @@ public class DelegateExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new DelegateExpressionBase(_ => null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/DelegateResultExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/DelegateResultExpressionTests.cs
@@ -31,6 +31,16 @@ public class DelegateResultExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new DelegateResultExpressionBase(_ => Result<object?>.Success(null));
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ElementAtExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ElementAtExpressionTests.cs
@@ -87,6 +87,16 @@ public class ElementAtExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ElementAtExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ElementAtOrDefaultExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ElementAtOrDefaultExpressionTests.cs
@@ -143,6 +143,16 @@ public class ElementAtOrDefaultExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ElementAtOrDefaultExpressionBase(new EmptyExpression(), new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/EmptyExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/EmptyExpressionTests.cs
@@ -3,6 +3,16 @@
 public class EmptyExpressionTests
 {
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new EmptyExpressionBase();
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/EqualsExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/EqualsExpressionTests.cs
@@ -83,6 +83,16 @@ public class EqualsExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new EqualsExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ErrorExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ErrorExpressionTests.cs
@@ -46,6 +46,16 @@ public class ErrorExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ErrorExpressionBase(new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/EvaluatableExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/EvaluatableExpressionTests.cs
@@ -59,6 +59,16 @@ public class EvaluatableExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new EvaluatableExpressionBase(new SingleEvaluatable(new EmptyExpression(), new EqualsOperator(), new EmptyExpression()));
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+    
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FalseExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FalseExpressionTests.cs
@@ -31,6 +31,16 @@ public class FalseExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new FalseExpressionBase();
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FieldExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FieldExpressionTests.cs
@@ -130,6 +130,16 @@ public class FieldExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new FieldExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FirstExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FirstExpressionTests.cs
@@ -143,6 +143,16 @@ public class FirstExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new FirstExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FirstOrDefaultExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/FirstOrDefaultExpressionTests.cs
@@ -157,6 +157,16 @@ public class FirstOrDefaultExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new FirstOrDefaultExpressionBase(new EmptyExpression(), null, null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/GroupByExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/GroupByExpressionTests.cs
@@ -57,6 +57,16 @@ public class GroupByExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new GroupByExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/IfExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/IfExpressionTests.cs
@@ -17,6 +17,16 @@ public class IfExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new IfExpressionBase(new SingleEvaluatable(new EmptyExpression(), new EqualsOperator(), new EmptyExpression()), new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/InvalidExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/InvalidExpressionTests.cs
@@ -76,6 +76,16 @@ public class InvalidExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new InvalidExpressionBase(new EmptyExpression(), Enumerable.Empty<Expression>());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/LastExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/LastExpressionTests.cs
@@ -129,6 +129,16 @@ public class LastExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new LastExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/LastOrDefaultExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/LastOrDefaultExpressionTests.cs
@@ -157,6 +157,16 @@ public class LastOrDefaultExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new LastOrDefaultExpressionBase(new EmptyExpression(), null, null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/LeftExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/LeftExpressionTests.cs
@@ -142,6 +142,16 @@ public class LeftExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new LeftExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/MaxExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/MaxExpressionTests.cs
@@ -73,6 +73,16 @@ public class MaxExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new MaxExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/MinExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/MinExpressionTests.cs
@@ -73,6 +73,16 @@ public class MinExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new MinExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NotEqualsExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NotEqualsExpressionTests.cs
@@ -99,6 +99,16 @@ public class NotEqualsExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new NotEqualsExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NotExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NotExpressionTests.cs
@@ -59,6 +59,16 @@ public class NotExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new NotExpressionBase(new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NowExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/NowExpressionTests.cs
@@ -49,4 +49,14 @@ public class NowExpressionTests
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(5));
     }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new NowExpressionBase(null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
 }

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/OfTypeExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/OfTypeExpressionTests.cs
@@ -58,6 +58,16 @@ public class OfTypeExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new OfTypeExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/OperatorExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/OperatorExpressionTests.cs
@@ -37,6 +37,16 @@ public class OperatorExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new OperatorExpressionBase(new EmptyExpression(), new EmptyExpression(), new EqualsOperator());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/OrExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/OrExpressionTests.cs
@@ -87,6 +87,16 @@ public class OrExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new OrExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/OrderByExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/OrderByExpressionTests.cs
@@ -177,6 +177,16 @@ public class OrderByExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new OrderByExpressionBase(new EmptyExpression(), Enumerable.Empty<Expression>());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/RightExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/RightExpressionTests.cs
@@ -142,6 +142,16 @@ public class RightExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new RightExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SelectExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SelectExpressionTests.cs
@@ -57,6 +57,16 @@ public class SelectExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new SelectExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SequenceExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SequenceExpressionTests.cs
@@ -115,6 +115,16 @@ public class SequenceExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new SequenceExpressionBase(Enumerable.Empty<Expression>());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SingleExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SingleExpressionTests.cs
@@ -157,6 +157,16 @@ public class SingleExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new SingleExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SingleOrDefaultExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SingleOrDefaultExpressionTests.cs
@@ -185,6 +185,16 @@ public class SingleOrDefaultExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new SingleOrDefaultExpressionBase(new EmptyExpression(), null, null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SkipExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SkipExpressionTests.cs
@@ -71,6 +71,16 @@ public class SkipExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new SkipExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringConcatenateExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringConcatenateExpressionTests.cs
@@ -125,6 +125,16 @@ public class StringConcatenateExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new StringConcatenateExpressionBase(Enumerable.Empty<Expression>());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringFindExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringFindExpressionTests.cs
@@ -20,7 +20,7 @@ public class StringFindExpressionTests
     public void Evaluate_Returns_Invalid_When_FindExpression_Returns_Non_String_Value()
     {
         // Arrange
-        var sut = new StringFindExpression(new ConstantExpression("Hello world"), new ConstantExpression(null));
+        var sut = new StringFindExpression(new ConstantExpression("Hello world"), new ConstantExpression(default(object?)));
 
         // Act
         var result = sut.Evaluate();
@@ -34,7 +34,7 @@ public class StringFindExpressionTests
     public void Evaluate_Returns_Invalid_When_Expression_Returns_Non_String_Value()
     {
         // Arrange
-        var sut = new StringFindExpression(new ConstantExpression(null), new ConstantExpression("e"));
+        var sut = new StringFindExpression(new ConstantExpression(default(object?)), new ConstantExpression("e"));
 
         // Act
         var result = sut.Evaluate();
@@ -56,6 +56,16 @@ public class StringFindExpressionTests
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().BeEquivalentTo("Hello world".IndexOf("e"));
+    }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new StringFindExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
     }
 
     [Fact]

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringLengthExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringLengthExpressionTests.cs
@@ -32,7 +32,7 @@ public class StringLengthExpressionTests
     public void Evaluate_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new StringLengthExpression(new ConstantExpression(null));
+        var sut = new StringLengthExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.Evaluate();
@@ -72,7 +72,7 @@ public class StringLengthExpressionTests
     public void EvaluateTyped_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new StringLengthExpression(new ConstantExpression(null));
+        var sut = new StringLengthExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.EvaluateTyped();
@@ -82,7 +82,16 @@ public class StringLengthExpressionTests
         actual.ErrorMessage.Should().Be("Expression must be of type string");
     }
 
-   
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new StringLengthExpressionBase(new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
     [Fact]
     public void Can_Determine_Descriptor_Provider()
     {

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringReplaceExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/StringReplaceExpressionTests.cs
@@ -20,7 +20,7 @@ public class StringReplaceExpressionTests
     public void Evaluate_Returns_Invalid_When_FindExpression_Returns_Non_String_Value()
     {
         // Arrange
-        var sut = new StringReplaceExpression(new ConstantExpression("Hello world"), new ConstantExpression(null), new ConstantExpression("f"));
+        var sut = new StringReplaceExpression(new ConstantExpression("Hello world"), new ConstantExpression(default(object?)), new ConstantExpression("f"));
 
         // Act
         var result = sut.Evaluate();
@@ -34,7 +34,7 @@ public class StringReplaceExpressionTests
     public void Evaluate_Returns_Invalid_When_ReplaceExpression_Returns_Non_String_Value()
     {
         // Arrange
-        var sut = new StringReplaceExpression(new ConstantExpression("Hello world"), new ConstantExpression("e"), new ConstantExpression(null));
+        var sut = new StringReplaceExpression(new ConstantExpression("Hello world"), new ConstantExpression("e"), new ConstantExpression(default(object?)));
 
         // Act
         var result = sut.Evaluate();
@@ -48,7 +48,7 @@ public class StringReplaceExpressionTests
     public void Evaluate_Returns_Invalid_When_Expression_Returns_Non_String_Value()
     {
         // Arrange
-        var sut = new StringReplaceExpression(new ConstantExpression(null), new ConstantExpression("e"), new ConstantExpression("f"));
+        var sut = new StringReplaceExpression(new ConstantExpression(default(object?)), new ConstantExpression("e"), new ConstantExpression("f"));
 
         // Act
         var result = sut.Evaluate();
@@ -84,5 +84,15 @@ public class StringReplaceExpressionTests
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().Be("Hello world".Replace("e", "f"));
+    }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new StringReplaceExpressionBase(new EmptyExpression(), new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
     }
 }

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SubstringExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SubstringExpressionTests.cs
@@ -198,6 +198,16 @@ public class SubstringExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new SubstringExpressionBase(new EmptyExpression(), new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SumExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SumExpressionTests.cs
@@ -171,6 +171,16 @@ public class SumExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new SumExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SwitchExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/SwitchExpressionTests.cs
@@ -49,6 +49,16 @@ public class SwitchExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new SwitchExpressionBase(Enumerable.Empty<Case>(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TakeExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TakeExpressionTests.cs
@@ -71,6 +71,16 @@ public class TakeExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new TakeExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToLowerCaseExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToLowerCaseExpressionTests.cs
@@ -32,7 +32,7 @@ public class ToLowerCaseExpressionTests
     public void Evaluate_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new ToLowerCaseExpression(new ConstantExpression(null));
+        var sut = new ToLowerCaseExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.Evaluate();
@@ -73,7 +73,7 @@ public class ToLowerCaseExpressionTests
     public void EvaluateTyped_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new ToLowerCaseExpression(new ConstantExpression(null));
+        var sut = new ToLowerCaseExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.EvaluateTyped();
@@ -81,6 +81,16 @@ public class ToLowerCaseExpressionTests
         // Assert
         actual.Status.Should().Be(ResultStatus.Invalid);
         actual.ErrorMessage.Should().Be("Expression must be of type string");
+    }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ToLowerCaseExpressionBase(new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
     }
 
     [Fact]

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToPascalCaseExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToPascalCaseExpressionTests.cs
@@ -32,7 +32,7 @@ public class ToPascalCaseExpressionTests
     public void Evaluate_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new ToPascalCaseExpression(new ConstantExpression(null));
+        var sut = new ToPascalCaseExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.Evaluate();
@@ -73,7 +73,7 @@ public class ToPascalCaseExpressionTests
     public void EvaluateTyped_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new ToPascalCaseExpression(new ConstantExpression(null));
+        var sut = new ToPascalCaseExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.EvaluateTyped();
@@ -81,6 +81,16 @@ public class ToPascalCaseExpressionTests
         // Assert
         actual.Status.Should().Be(ResultStatus.Invalid);
         actual.ErrorMessage.Should().Be("Expression must be of type string");
+    }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ToPascalCaseExpressionBase(new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
     }
 
     [Fact]

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToUpperCaseExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/ToUpperCaseExpressionTests.cs
@@ -32,7 +32,7 @@ public class ToUpperCaseExpressionTests
     public void Evaluate_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new ToUpperCaseExpression(new ConstantExpression(null));
+        var sut = new ToUpperCaseExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.Evaluate();
@@ -73,7 +73,7 @@ public class ToUpperCaseExpressionTests
     public void EvaluateTyped_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new ToUpperCaseExpression(new ConstantExpression(null));
+        var sut = new ToUpperCaseExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.EvaluateTyped();
@@ -81,6 +81,16 @@ public class ToUpperCaseExpressionTests
         // Assert
         actual.Status.Should().Be(ResultStatus.Invalid);
         actual.ErrorMessage.Should().Be("Expression must be of type string");
+    }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new ToUpperCaseExpressionBase(new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
     }
 
     [Fact]

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TodayExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TodayExpressionTests.cs
@@ -49,4 +49,15 @@ public class TodayExpressionTests
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().BeCloseTo(DateTime.Now.Date, TimeSpan.FromDays(1));
     }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new TodayExpressionBase(null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
 }

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimEndExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimEndExpressionTests.cs
@@ -123,6 +123,16 @@ public class TrimEndExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new TrimEndExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimExpressionTests.cs
@@ -45,7 +45,7 @@ public class TrimExpressionTests
     public void Evaluate_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new TrimExpression(new ConstantExpression(null));
+        var sut = new TrimExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.Evaluate();
@@ -113,7 +113,7 @@ public class TrimExpressionTests
     public void EvaluateTyped_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new TrimExpression(new ConstantExpression(null));
+        var sut = new TrimExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.EvaluateTyped();
@@ -121,6 +121,16 @@ public class TrimExpressionTests
         // Assert
         actual.Status.Should().Be(ResultStatus.Invalid);
         actual.ErrorMessage.Should().Be("Expression must be of type string");
+    }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new TrimExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
     }
 
     [Fact]

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimStartExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrimStartExpressionTests.cs
@@ -45,7 +45,7 @@ public class TrimStartExpressionTests
     public void Evaluate_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new TrimStartExpression(new ConstantExpression(null));
+        var sut = new TrimStartExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.Evaluate();
@@ -112,7 +112,7 @@ public class TrimStartExpressionTests
     public void EvaluateTyped_Returns_Invalid_When_Expression_Is_Null()
     {
         // Arrange
-        var sut = new TrimStartExpression(new ConstantExpression(null));
+        var sut = new TrimStartExpression(new ConstantExpression(default(object?)));
 
         // Act
         var actual = sut.EvaluateTyped();
@@ -120,6 +120,16 @@ public class TrimStartExpressionTests
         // Assert
         actual.Status.Should().Be(ResultStatus.Invalid);
         actual.ErrorMessage.Should().Be("Expression must be of type string");
+    }
+
+    [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new TrimStartExpressionBase(new EmptyExpression(), null);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
     }
 
     [Fact]

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrueExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TrueExpressionTests.cs
@@ -31,6 +31,16 @@ public class TrueExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new TrueExpressionBase();
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TypedConstantExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TypedConstantExpressionTests.cs
@@ -45,6 +45,16 @@ public class TypedConstantExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new TypedConstantExpressionBase<bool>(default);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TypedDelegateExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/TypedDelegateExpressionTests.cs
@@ -31,6 +31,16 @@ public class TypedDelegateExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new TypedDelegateExpressionBase<bool>(_ => default);
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain.Tests/Unit/Expressions/WhereExpressionTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Expressions/WhereExpressionTests.cs
@@ -70,6 +70,16 @@ public class WhereExpressionTests
     }
 
     [Fact]
+    public void BaseClass_Cannot_Evaluate()
+    {
+        // Arrange
+        var expression = new WhereExpressionBase(new EmptyExpression(), new EmptyExpression());
+
+        // Act & Assert
+        expression.Invoking(x => x.Evaluate()).Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
     public void Can_Determine_Descriptor_Provider()
     {
         // Arrange

--- a/src/ExpressionFramework.Domain/Evaluatables/ComposableEvaluatable.cs
+++ b/src/ExpressionFramework.Domain/Evaluatables/ComposableEvaluatable.cs
@@ -24,3 +24,7 @@ public partial record ComposableEvaluatable
         => Operator.Evaluate(context, LeftExpression, RightExpression);
 }
 
+public partial record ComposableEvaluatableBase
+{
+    public override Result<bool> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Evaluatables/ComposedEvaluatable.cs
+++ b/src/ExpressionFramework.Domain/Evaluatables/ComposedEvaluatable.cs
@@ -20,13 +20,13 @@ public partial record ComposedEvaluatable : IValidatableObject
     {
         var groupCounter = 0;
         var index = 0;
-        foreach (var condition in Conditions)
+        foreach (var evaluatable in Conditions)
         {
-            if (condition.StartGroup)
+            if (evaluatable.StartGroup)
             {
                 groupCounter++;
             }
-            if (condition.EndGroup)
+            if (evaluatable.EndGroup)
             {
                 groupCounter--;
             }
@@ -54,9 +54,9 @@ public partial record ComposedEvaluatable : IValidatableObject
 
     private Result<bool> EvaluateSimpleConditions(object? context, IEnumerable<ComposableEvaluatable> conditions)
     {
-        foreach (var condition in conditions)
+        foreach (var evaluatable in conditions)
         {
-            var itemResult = IsItemValid(context, condition);
+            var itemResult = IsItemValid(context, evaluatable);
             if (!itemResult.IsSuccessful())
             {
                 return itemResult;
@@ -74,16 +74,16 @@ public partial record ComposedEvaluatable : IValidatableObject
     private Result<bool> EvaluateComplexConditions(object? context, IEnumerable<ComposableEvaluatable> conditions)
     {
         var builder = new StringBuilder();
-        foreach (var condition in conditions)
+        foreach (var evaluatable in conditions)
         {
             if (builder.Length > 0)
             {
-                builder.Append(condition.Combination == Combination.And ? "&" : "|");
+                builder.Append(evaluatable.Combination == Combination.And ? "&" : "|");
             }
 
-            var prefix = condition.StartGroup ? "(" : string.Empty;
-            var suffix = condition.EndGroup ? ")" : string.Empty;
-            var itemResult = IsItemValid(context, condition);
+            var prefix = evaluatable.StartGroup ? "(" : string.Empty;
+            var suffix = evaluatable.EndGroup ? ")" : string.Empty;
+            var itemResult = IsItemValid(context, evaluatable);
             if (!itemResult.IsSuccessful())
             {
                 return itemResult;
@@ -165,4 +165,9 @@ public partial record ComposedEvaluatable : IValidatableObject
         => closeIndex == expression.Length
             ? string.Empty
             : expression.Substring(closeIndex + 1);
+}
+
+public partial record ComposedEvaluatableBase
+{
+    public override Result<bool> Evaluate(object? context) => throw new NotImplementedException();
 }

--- a/src/ExpressionFramework.Domain/Evaluatables/ConstantEvaluatable.cs
+++ b/src/ExpressionFramework.Domain/Evaluatables/ConstantEvaluatable.cs
@@ -10,3 +10,7 @@ public partial record ConstantEvaluatable
         => Result<bool>.Success(Value);
 }
 
+public partial record ConstantEvaluatableBase
+{
+    public override Result<bool> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Evaluatables/DelegateEvaluatable.cs
+++ b/src/ExpressionFramework.Domain/Evaluatables/DelegateEvaluatable.cs
@@ -9,3 +9,8 @@ public partial record DelegateEvaluatable
     public override Result<bool> Evaluate(object? context)
         => Result<bool>.Success(Value.Invoke());
 }
+
+public partial record DelegateEvaluatableBase
+{
+    public override Result<bool> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Evaluatables/SingleEvaluatable.cs
+++ b/src/ExpressionFramework.Domain/Evaluatables/SingleEvaluatable.cs
@@ -13,3 +13,8 @@ public partial record SingleEvaluatable
     public override Result<bool> Evaluate(object? context)
         => Operator.Evaluate(context, LeftExpression, RightExpression);
 }
+
+public partial record SingleEvaluatableBase
+{
+    public override Result<bool> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/AggregateExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/AggregateExpression.cs
@@ -41,3 +41,7 @@ public partial record AggregateExpression
     }
 }
 
+public partial record AggregateExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/AllExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/AllExpression.cs
@@ -40,3 +40,7 @@ public partial record AllExpression : ITypedExpression<bool>
         );
 }
 
+public partial record AllExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/AndExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/AndExpression.cs
@@ -21,3 +21,7 @@ public partial record AndExpression : ITypedExpression<bool>
         );
 }
 
+public partial record AndExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/AnyExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/AnyExpression.cs
@@ -37,3 +37,7 @@ public partial record AnyExpression : ITypedExpression<bool>
         );
 }
 
+public partial record AnyExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ChainedExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ChainedExpression.cs
@@ -34,3 +34,8 @@ public partial record ChainedExpression
         return result;
     }
 }
+
+public partial record ChainedExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/CompoundExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/CompoundExpression.cs
@@ -17,3 +17,7 @@ public partial record CompoundExpression
         => Aggregator.Aggregate(context, FirstExpression, SecondExpression);
 }
 
+public partial record CompoundExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ConstantExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ConstantExpression.cs
@@ -10,3 +10,8 @@ public partial record ConstantExpression
     public override Result<object?> Evaluate(object? context)
         => Result<object?>.Success(Value);
 }
+
+public partial record ConstantExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ContextExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ContextExpression.cs
@@ -11,3 +11,8 @@ public partial record ContextExpression
     public override Result<object?> Evaluate(object? context)
         => Result<object?>.Success(context);
 }
+
+public partial record ContextExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/CountExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/CountExpression.cs
@@ -36,3 +36,8 @@ public partial record CountExpression : ITypedExpression<int>
             resultValueType: typeof(int)
         );
 }
+
+public partial record CountExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/DelegateExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/DelegateExpression.cs
@@ -10,3 +10,8 @@ public partial record DelegateExpression
     public override Result<object?> Evaluate(object? context)
         => Result<object?>.Success(Value.Invoke(context));
 }
+
+public partial record DelegateExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/DelegateResultExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/DelegateResultExpression.cs
@@ -11,3 +11,7 @@ public partial record DelegateResultExpression
         => Result.Invoke(context);
 }
 
+public partial record DelegateResultExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ElementAtExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ElementAtExpression.cs
@@ -35,3 +35,8 @@ public partial record ElementAtExpression
             resultValueType: typeof(object)
         );
 }
+
+public partial record ElementAtExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ElementAtOrDefaultExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ElementAtOrDefaultExpression.cs
@@ -32,3 +32,7 @@ public partial record ElementAtOrDefaultExpression
         );
 }
 
+public partial record ElementAtOrDefaultExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/EmptyExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/EmptyExpression.cs
@@ -8,3 +8,8 @@ public partial record EmptyExpression
     public override Result<object?> Evaluate(object? context)
         => Result<object?>.Success(null);
 }
+
+public partial record EmptyExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/EqualsExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/EqualsExpression.cs
@@ -32,3 +32,8 @@ public partial record EqualsExpression : ITypedExpression<bool>
             null,
             "Boolean expression to perform Equals operation on");
 }
+
+public partial record EqualsExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ErrorExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ErrorExpression.cs
@@ -14,3 +14,8 @@ public partial record ErrorExpression
                 ? Result<object?>.Error(result.Value!)
                 : Result<object?>.FromExistingResult(result));
 }
+
+public partial record ErrorExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/EvaluatableExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/EvaluatableExpression.cs
@@ -17,3 +17,7 @@ public partial record EvaluatableExpression : ITypedExpression<bool>
         => Condition.Evaluate(context);
 }
 
+public partial record EvaluatableExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/FalseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/FalseExpression.cs
@@ -12,3 +12,7 @@ public partial record FalseExpression : ITypedExpression<bool>
         => Result<bool>.Success(false);
 }
 
+public partial record FalseExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/FieldExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/FieldExpression.cs
@@ -62,3 +62,8 @@ public partial record FieldExpression
         return Result<object?>.Success(returnValue);
     }
 }
+
+public partial record FieldExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/FirstExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/FirstExpression.cs
@@ -27,3 +27,7 @@ public partial record FirstExpression
         );
 }
 
+public partial record FirstExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/FirstOrDefaultExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/FirstOrDefaultExpression.cs
@@ -28,3 +28,7 @@ public partial record FirstOrDefaultExpression
         );
 }
 
+public partial record FirstOrDefaultExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/GroupByExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/GroupByExpression.cs
@@ -41,3 +41,7 @@ public partial record GroupByExpression
     }
 }
 
+public partial record GroupByExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/IfExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/IfExpression.cs
@@ -36,3 +36,8 @@ public partial record IfExpression
         return Result<object?>.Success(null);
     }
 }
+
+public partial record IfExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/InvalidExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/InvalidExpression.cs
@@ -40,3 +40,7 @@ public partial record InvalidExpression
     }
 }
 
+public partial record InvalidExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/LastExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/LastExpression.cs
@@ -26,3 +26,8 @@ public partial record LastExpression
             resultValueType: typeof(object)
         );
 }
+
+public partial record LastExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/LastOrDefaultExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/LastOrDefaultExpression.cs
@@ -28,3 +28,7 @@ public partial record LastOrDefaultExpression
         );
 }
 
+public partial record LastOrDefaultExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/LeftExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/LeftExpression.cs
@@ -34,3 +34,7 @@ public partial record LeftExpression : ITypedExpression<string>
             "This result will be returned when the context is of type string");
 }
 
+public partial record LeftExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/MaxExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/MaxExpression.cs
@@ -20,3 +20,7 @@ public partial record MaxExpression
         );
 }
 
+public partial record MaxExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/MinExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/MinExpression.cs
@@ -20,3 +20,7 @@ public partial record MinExpression
         );
 }
 
+public partial record MinExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/NotEqualsExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/NotEqualsExpression.cs
@@ -32,3 +32,8 @@ public partial record NotEqualsExpression : ITypedExpression<bool>
             null,
             "Boolean expression to perform NotEquals operation on");
 }
+
+public partial record NotEqualsExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/NotExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/NotExpression.cs
@@ -20,3 +20,7 @@ public partial record NotExpression : ITypedExpression<bool>
                 : result);
 }
 
+public partial record NotExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/NowExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/NowExpression.cs
@@ -17,3 +17,7 @@ public partial record NowExpression : ITypedExpression<DateTime>
     }
 }
 
+public partial record NowExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/OfTypeExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/OfTypeExpression.cs
@@ -23,3 +23,7 @@ public partial record OfTypeExpression
     }
 }
 
+public partial record OfTypeExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/OperatorExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/OperatorExpression.cs
@@ -21,3 +21,7 @@ public partial record OperatorExpression : ITypedExpression<bool>
         => Operator.Evaluate(context, LeftExpression, RightExpression);
 }
 
+public partial record OperatorExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/OrExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/OrExpression.cs
@@ -21,3 +21,7 @@ public partial record OrExpression : ITypedExpression<bool>
         );
 }
 
+public partial record OrExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/OrderByExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/OrderByExpression.cs
@@ -90,3 +90,7 @@ public partial record OrderByExpression
     }
 }
 
+public partial record OrderByExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/RightExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/RightExpression.cs
@@ -34,3 +34,7 @@ public partial record RightExpression : ITypedExpression<string>
             "This result will be returned when the context is of type string");
 }
 
+public partial record RightExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/SelectExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SelectExpression.cs
@@ -14,3 +14,7 @@ public partial record SelectExpression
             .Select(x => SelectorExpression.Evaluate(x))));
 }
 
+public partial record SelectExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/SequenceExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SequenceExpression.cs
@@ -31,3 +31,7 @@ public partial record SequenceExpression : ITypedExpression<IEnumerable<object?>
     }
 }
 
+public partial record SequenceExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/SingleExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SingleExpression.cs
@@ -30,3 +30,7 @@ public partial record SingleExpression
         );
 }
 
+public partial record SingleExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/SingleOrDefaultExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SingleOrDefaultExpression.cs
@@ -31,3 +31,7 @@ public partial record SingleOrDefaultExpression
         );
 }
 
+public partial record SingleOrDefaultExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/SkipExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SkipExpression.cs
@@ -23,3 +23,8 @@ public partial record SkipExpression
             .Select(x => Result<object?>.Success(x)));
     }
 }
+
+public partial record SkipExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringConcatenateExpression.cs
@@ -32,3 +32,7 @@ public partial record StringConcatenateExpression : ITypedExpression<string>
     }
 }
 
+public partial record StringConcatenateExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/StringFindExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringFindExpression.cs
@@ -30,3 +30,7 @@ public partial record StringFindExpression : ITypedExpression<int>
     }
 }
 
+public partial record StringFindExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/StringLengthExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringLengthExpression.cs
@@ -20,3 +20,7 @@ public partial record StringLengthExpression : ITypedExpression<int>
                 : Result<int>.FromExistingResult(result));
 }
 
+public partial record StringLengthExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/StringReplaceExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/StringReplaceExpression.cs
@@ -37,3 +37,7 @@ public partial record StringReplaceExpression : ITypedExpression<string>
     }
 }
 
+public partial record StringReplaceExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/SubstringExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SubstringExpression.cs
@@ -54,3 +54,8 @@ public partial record SubstringExpression : ITypedExpression<string>
             : Result<string>.Invalid("Index and length must refer to a location within the string");
     }
 }
+
+public partial record SubstringExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/SumExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SumExpression.cs
@@ -49,3 +49,8 @@ public partial record SumExpression
         return Result<object?>.Invalid("Could only compute sum of numeric values");
     }
 }
+
+public partial record SumExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/SwitchExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/SwitchExpression.cs
@@ -52,3 +52,8 @@ public partial record SwitchExpression
         return Result<(bool ConditionResult, Result<object?> ExpressionResult)>.Success((false, Result<object?>.Success(null)));
     }
 }
+
+public partial record SwitchExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/TakeExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TakeExpression.cs
@@ -25,3 +25,7 @@ public partial record TakeExpression
     public TakeExpression(IEnumerable enumerable, int count) : this(new ConstantExpression(enumerable), new ConstantExpression(count)) { }
 }
 
+public partial record TakeExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ToLowerCaseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ToLowerCaseExpression.cs
@@ -19,3 +19,8 @@ public partial record ToLowerCaseExpression : ITypedExpression<string>
                 ? Result<string>.Success(result.Value!.ToLower())
                 : result);
 }
+
+public partial record ToLowerCaseExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ToPascalCaseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ToPascalCaseExpression.cs
@@ -29,3 +29,8 @@ public partial record ToPascalCaseExpression : ITypedExpression<string>
         return value;
     }
 }
+
+public partial record ToPascalCaseExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/ToUpperCaseExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/ToUpperCaseExpression.cs
@@ -19,3 +19,8 @@ public partial record ToUpperCaseExpression : ITypedExpression<string>
                 ? Result<string>.Success(result.Value!.ToUpper())
                 : result);
 }
+
+public partial record ToUpperCaseExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/TodayExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TodayExpression.cs
@@ -17,3 +17,7 @@ public partial record TodayExpression : ITypedExpression<DateTime>
     }
 }
 
+public partial record TodayExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/TrimEndExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TrimEndExpression.cs
@@ -39,3 +39,7 @@ public partial record TrimEndExpression : ITypedExpression<string>
             "This result will be returned when the expression is of type string");
 }
 
+public partial record TrimEndExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/TrimExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TrimExpression.cs
@@ -39,3 +39,7 @@ public partial record TrimExpression : ITypedExpression<string>
             "This result will be returned when the expression is of type string");
 }
 
+public partial record TrimExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/TrimStartExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TrimStartExpression.cs
@@ -39,3 +39,7 @@ public partial record TrimStartExpression : ITypedExpression<string>
             "This result will be returned when the expression is of type string");
 }
 
+public partial record TrimStartExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/TrueExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TrueExpression.cs
@@ -12,3 +12,7 @@ public partial record TrueExpression : ITypedExpression<bool>
         => Result<bool>.Success(true);
 }
 
+public partial record TrueExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/TypedConstantExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TypedConstantExpression.cs
@@ -17,3 +17,7 @@ public partial record TypedConstantExpression<T> : ITypedExpression<T>, IUntyped
         => new ConstantExpression(Value);
 }
 
+public partial record TypedConstantExpressionBase<T>
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/TypedDelegateExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/TypedDelegateExpression.cs
@@ -17,3 +17,7 @@ public partial record TypedDelegateExpression<T> : ITypedExpression<T>, IUntyped
         => new DelegateExpression(context => Value.Invoke(context));
 }
 
+public partial record TypedDelegateExpressionBase<T>
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}

--- a/src/ExpressionFramework.Domain/Expressions/WhereExpression.cs
+++ b/src/ExpressionFramework.Domain/Expressions/WhereExpression.cs
@@ -34,3 +34,7 @@ public partial record WhereExpression
     }
 }
 
+public partial record WhereExpressionBase
+{
+    public override Result<object?> Evaluate(object? context) => throw new NotImplementedException();
+}


### PR DESCRIPTION
Use next version of ModelFramework.CodeGeneration, so domain objects can't get constructed with invalid state