### PR TITLE
Models

### DIFF
--- a/ExpressionFramework.sln
+++ b/ExpressionFramework.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Parser"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Parser.Tests", "src\ExpressionFramework.Parser.Tests\ExpressionFramework.Parser.Tests.csproj", "{27EB4107-7085-49CC-8834-58D706E3A00D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpressionFramework.Domain.Models", "src\ExpressionFramework.Domain.Models\ExpressionFramework.Domain.Models.csproj", "{78BF691F-D045-43EA-A692-1B1C2060BCCF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{27EB4107-7085-49CC-8834-58D706E3A00D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27EB4107-7085-49CC-8834-58D706E3A00D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27EB4107-7085-49CC-8834-58D706E3A00D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78BF691F-D045-43EA-A692-1B1C2060BCCF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78BF691F-D045-43EA-A692-1B1C2060BCCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78BF691F-D045-43EA-A692-1B1C2060BCCF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78BF691F-D045-43EA-A692-1B1C2060BCCF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/AbstractModels.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/AbstractModels.cs
@@ -1,0 +1,16 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders;
+
+[ExcludeFromCodeCoverage]
+public class AbstractModels : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Namespaces.DomainModels;
+
+    protected override bool EnableEntityInheritance => true;
+    protected override bool EnableBuilderInhericance => true;
+
+    public override object CreateModel()
+        => GetImmutableBuilderClasses(
+            GetAbstractModels(),
+            Constants.Namespaces.Domain,
+            Constants.Namespaces.DomainModels);
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/AbstractNonGenericModels.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/AbstractNonGenericModels.cs
@@ -1,0 +1,17 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders;
+
+[ExcludeFromCodeCoverage]
+public class AbstractNonGenericModels : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Namespaces.DomainModels;
+
+    protected override bool EnableEntityInheritance => true;
+    protected override bool EnableBuilderInhericance => true;
+    protected override string FileNameSuffix => ".nongeneric.template.generated";
+
+    public override object CreateModel()
+        => GetImmutableNonGenericBuilderClasses(
+            GetAbstractModels(),
+            Constants.Namespaces.Domain,
+            Constants.Namespaces.DomainModels);
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Aggregators/AggregatorModelFactory.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Aggregators/AggregatorModelFactory.cs
@@ -1,0 +1,20 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.Aggregators;
+
+[ExcludeFromCodeCoverage]
+public class AggregatorModelFactory : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Namespaces.DomainModels;
+
+    public override object CreateModel()
+        => CreateBuilderFactoryModels(
+            GetOverrideModels(typeof(Models.IAggregator)),
+            new(
+                Constants.Namespaces.DomainModels,
+                nameof(AggregatorModelFactory),
+                Constants.TypeNames.Aggregator,
+                Constants.Namespaces.DomainModelsAggregators,
+                Constants.Types.AggregatorModel,
+                Constants.Namespaces.DomainAggregators
+            )
+        );
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Aggregators/OverrideModels.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Aggregators/OverrideModels.cs
@@ -1,0 +1,19 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.Aggregators;
+
+[ExcludeFromCodeCoverage]
+public class OverrideModels : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Paths.AggregatorModels;
+
+    protected override bool EnableEntityInheritance => true;
+    protected override bool EnableBuilderInhericance => true;
+    protected override IClass? BaseClass => CreateBaseclass(typeof(Models.IAggregator), Constants.Namespaces.Domain);
+    protected override string BaseClassBuilderNamespace => Constants.Namespaces.DomainModels;
+    protected override ArgumentValidationType ValidateArgumentsInConstructor => ArgumentValidationType.None; // there are no properties in aggregators, so this is not necessary
+
+    public override object CreateModel()
+        => GetImmutableBuilderClasses(
+            GetOverrideModels(typeof(Models.IAggregator)),
+            Constants.Namespaces.DomainAggregators,
+            CurrentNamespace);
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/CoreModels.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/CoreModels.cs
@@ -1,0 +1,13 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders;
+
+[ExcludeFromCodeCoverage]
+public class CoreModels : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Namespaces.DomainModels;
+
+    public override object CreateModel()
+        => GetImmutableBuilderClasses(
+            GetCoreModels(),
+            Constants.Namespaces.Domain,
+            Constants.Namespaces.DomainModels);
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Evaluatables/EvaluatableModelFactory.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Evaluatables/EvaluatableModelFactory.cs
@@ -1,0 +1,20 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.Evaluatables;
+
+[ExcludeFromCodeCoverage]
+public class EvaluatableModelFactory : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Namespaces.DomainModels;
+
+    public override object CreateModel()
+        => CreateBuilderFactoryModels(
+            GetOverrideModels(typeof(IEvaluatable)),
+            new(
+                Constants.Namespaces.DomainModels,
+                nameof(EvaluatableModelFactory),
+                Constants.TypeNames.Evaluatable,
+                Constants.Namespaces.DomainModelsEvaluatables,
+                Constants.Types.EvaluatableModel,
+                Constants.Namespaces.DomainEvaluatables
+            )
+        );
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Evaluatables/OverrideModels.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Evaluatables/OverrideModels.cs
@@ -1,0 +1,18 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.Evaluatables;
+
+[ExcludeFromCodeCoverage]
+public class OverrideModels : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Paths.EvaluatableModels;
+
+    protected override bool EnableEntityInheritance => true;
+    protected override bool EnableBuilderInhericance => true;
+    protected override IClass? BaseClass => CreateBaseclass(typeof(IEvaluatable), Constants.Namespaces.Domain);
+    protected override string BaseClassBuilderNamespace => Constants.Namespaces.DomainModels;
+
+    public override object CreateModel()
+        => GetImmutableBuilderClasses(
+            GetOverrideModels(typeof(IEvaluatable)),
+            Constants.Namespaces.DomainEvaluatables,
+            CurrentNamespace);
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
@@ -18,7 +18,7 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
     protected override string ProjectName => Constants.ProjectName;
     protected override Type BuilderClassCollectionType => typeof(IEnumerable<>);
     protected override bool AddBackingFieldsForCollectionProperties => true;
-    protected override bool AddPrivateSetters => true;
+    protected override bool AddNullChecks => true;
     protected override ArgumentValidationType ValidateArgumentsInConstructor => ArgumentValidationType.Shared;
 
     protected override void FixImmutableBuilderProperty(ClassPropertyBuilder property, string typeName)

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
@@ -24,13 +24,10 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
     {
         if (typeName.WithoutProcessedGenerics().GetClassName() == Constants.Types.ITypedExpression)
         {
-            property.ConvertSinglePropertyToBuilderOnBuilder
-            (
-                $"{Constants.Namespaces.DomainContracts}.{Constants.Types.ITypedExpression}{BuilderName}<{typeName.GetGenericArguments()}>",
-                CreateAssignment(property, typeName),
-                builderName: BuilderName,
-                buildMethodName: BuilderBuildMethodName
-            );
+            var argumentType = $"{Constants.Namespaces.DomainContracts}.{Constants.Types.ITypedExpression}{BuilderName}<{typeName.GetGenericArguments()}>";
+            property.WithCustomBuilderConstructorInitializeExpressionSingleProperty(argumentType, CreateAssignment(property, typeName));
+            property.WithCustomBuilderArgumentTypeSingleProperty(argumentType, builderName: BuilderName);
+            property.WithCustomBuilderMethodParameterExpression(buildMethodName: BuilderBuildMethodName);
 
             AddSingleTypedExpressionPropertyBuilderOverload(property);
 
@@ -53,10 +50,9 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
             var init = BuilderName == "Builder"
                 ? $"{Constants.Namespaces.DomainBuilders}.{nameof(Expressions.ExpressionBuilderFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(x)"
                 : $"{Constants.Namespaces.DomainModels}.{nameof(Expressions.ExpressionModelFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(x)";
+            property.ConvertCollectionOnBuilderToEnumerable(false, RecordConcreteCollectionType.WithoutGenerics());
             property.ConvertCollectionPropertyToBuilderOnBuilder
             (
-                false,
-                RecordConcreteCollectionType.WithoutGenerics(),
                 $"{typeof(IEnumerable<>).WithoutGenerics()}<{Constants.Namespaces.DomainContracts}.{Constants.Types.ITypedExpression}{BuilderName}<{typeName.GetGenericArguments()}>>",
                 "{0} = source.{0}.Select(x => " + init + ").ToList()",
                 builderCollectionTypeName: BuilderClassCollectionType.WithoutGenerics(),

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
@@ -17,7 +17,6 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
     protected override Type RecordConcreteCollectionType => typeof(ReadOnlyValueCollection<>);
     protected override string ProjectName => Constants.ProjectName;
     protected override Type BuilderClassCollectionType => typeof(IEnumerable<>);
-    protected override bool AddBackingFieldsForCollectionProperties => true;
     protected override ArgumentValidationType ValidateArgumentsInConstructor => ArgumentValidationType.Shared;
 
     protected override void FixImmutableBuilderProperty(ClassPropertyBuilder property, string typeName)

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
@@ -18,7 +18,6 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
     protected override string ProjectName => Constants.ProjectName;
     protected override Type BuilderClassCollectionType => typeof(IEnumerable<>);
     protected override bool AddBackingFieldsForCollectionProperties => true;
-    protected override bool AddNullChecks => true;
     protected override ArgumentValidationType ValidateArgumentsInConstructor => ArgumentValidationType.Shared;
 
     protected override void FixImmutableBuilderProperty(ClassPropertyBuilder property, string typeName)

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
@@ -40,11 +40,11 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
                 // Allow a default value which implements ITypedExpression<T>, using a default constant value
                 if (BuilderName == "Model")
                 {
-                    property.SetDefaultValueForBuilderClassConstructor(new Literal($"{Constants.Namespaces.DomainModels}.{nameof(Expressions.ExpressionModelFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(new {Constants.Namespaces.DomainExpressions}.TypedConstantExpression<{typeName.GetGenericArguments()}>({typeName.GetGenericArguments().GetDefaultValue(property.IsNullable)}!))"));
+                    property.SetDefaultValueForBuilderClassConstructor(new Literal($"{Constants.Namespaces.DomainModels}.{nameof(Expressions.ExpressionModelFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(new {Constants.Namespaces.DomainExpressions}.TypedConstantExpression<{typeName.GetGenericArguments()}>({typeName.GetGenericArguments().GetDefaultValue(property.IsNullable, EnableNullableContext)}))"));
                 }
                 else
                 {
-                    property.SetDefaultValueForBuilderClassConstructor(new Literal($"{Constants.Namespaces.DomainBuilders}.{nameof(Expressions.ExpressionBuilderFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(new {Constants.Namespaces.DomainExpressions}.TypedConstantExpression<{typeName.GetGenericArguments()}>({typeName.GetGenericArguments().GetDefaultValue(property.IsNullable)}!))"));
+                    property.SetDefaultValueForBuilderClassConstructor(new Literal($"{Constants.Namespaces.DomainBuilders}.{nameof(Expressions.ExpressionBuilderFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(new {Constants.Namespaces.DomainExpressions}.TypedConstantExpression<{typeName.GetGenericArguments()}>({typeName.GetGenericArguments().GetDefaultValue(property.IsNullable, EnableNullableContext)}))"));
                 }
             }
         }

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkCSharpClassBase.cs
@@ -21,60 +21,83 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
     protected override bool AddPrivateSetters => true;
     protected override ArgumentValidationType ValidateArgumentsInConstructor => ArgumentValidationType.Shared;
 
-    protected virtual bool PerformBuilderStuff => true;
-
     protected override void FixImmutableBuilderProperty(ClassPropertyBuilder property, string typeName)
     {
-        if (PerformBuilderStuff)
+        if (typeName.WithoutProcessedGenerics().GetClassName() == Constants.Types.ITypedExpression)
         {
-            if (typeName.WithoutProcessedGenerics().GetClassName() == typeof(ITypedExpression<>).WithoutGenerics().GetClassName())
+            property.ConvertSinglePropertyToBuilderOnBuilder
+            (
+                $"{Constants.Namespaces.DomainContracts}.{Constants.Types.ITypedExpression}{BuilderName}<{typeName.GetGenericArguments()}>",
+                CreateAssignment(property, typeName),
+                builderName: BuilderName,
+                buildMethodName: BuilderBuildMethodName
+            );
+
+            AddSingleTypedExpressionPropertyBuilderOverload(property);
+
+            if (!property.IsNullable)
             {
-                var init = $"{Constants.Namespaces.DomainBuilders}.{nameof(Expressions.ExpressionBuilderFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(source.{{0}})";
-                property.ConvertSinglePropertyToBuilderOnBuilder
-                (
-                    $"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}Builder<{typeName.GetGenericArguments()}>",
-                    property.IsNullable
-                        ? "_{1}Delegate = new (() => source.{0} == null ? null : " + init + ")"
-                        : "_{1}Delegate = new (() => " + init + ")"
-                );
-
-                AddSingleTypedExpressionPropertyBuilderOverload(property);
-
-                if (!property.IsNullable)
+                // Allow a default value which implements ITypedExpression<T>, using a default constant value
+                if (BuilderName == "Model")
                 {
-                    // Allow a default value which implements ITypedExpression<T>, using a default constant value
+                    property.SetDefaultValueForBuilderClassConstructor(new Literal($"{Constants.Namespaces.DomainModels}.{nameof(Expressions.ExpressionModelFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(new {Constants.Namespaces.DomainExpressions}.TypedConstantExpression<{typeName.GetGenericArguments()}>({typeName.GetGenericArguments().GetDefaultValue(property.IsNullable)}!))"));
+                }
+                else
+                {
                     property.SetDefaultValueForBuilderClassConstructor(new Literal($"{Constants.Namespaces.DomainBuilders}.{nameof(Expressions.ExpressionBuilderFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(new {Constants.Namespaces.DomainExpressions}.TypedConstantExpression<{typeName.GetGenericArguments()}>({typeName.GetGenericArguments().GetDefaultValue(property.IsNullable)}!))"));
                 }
             }
-            else if (typeName.WithoutProcessedGenerics().GetClassName() == typeof(IMultipleTypedExpressions<>).WithoutGenerics().GetClassName())
-            {
-                // This is an ugly hack to transform IMultipleTypedExpression<T> in the code generation model to IEnumerable<ITypedExpression<T>> in the domain model.
-                var init = $"{Constants.Namespaces.DomainBuilders}.{nameof(Expressions.ExpressionBuilderFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(x)";
-                property.ConvertCollectionPropertyToBuilderOnBuilder
-                (
-                    false,
-                    RecordConcreteCollectionType.WithoutGenerics(),
-                    $"{typeof(IEnumerable<>).WithoutGenerics()}<{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}Builder<{typeName.GetGenericArguments()}>>",
-                    "{0} = source.{0}.Select(x => " + init + ").ToList()",
-                    builderCollectionTypeName: BuilderClassCollectionType.WithoutGenerics()
-                );
-                property.WithTypeName($"{typeof(IEnumerable<>).WithoutGenerics()}<{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}<{typeName.GetGenericArguments()}>>");
+        }
+        else if (typeName.WithoutProcessedGenerics().GetClassName() == typeof(IMultipleTypedExpressions<>).WithoutGenerics().GetClassName())
+        {
+            // This is an ugly hack to transform IMultipleTypedExpression<T> in the code generation model to IEnumerable<ITypedExpression<T>> in the domain model.
+            var init = BuilderName == "Builder"
+                ? $"{Constants.Namespaces.DomainBuilders}.{nameof(Expressions.ExpressionBuilderFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(x)"
+                : $"{Constants.Namespaces.DomainModels}.{nameof(Expressions.ExpressionModelFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(x)";
+            property.ConvertCollectionPropertyToBuilderOnBuilder
+            (
+                false,
+                RecordConcreteCollectionType.WithoutGenerics(),
+                $"{typeof(IEnumerable<>).WithoutGenerics()}<{Constants.Namespaces.DomainContracts}.{Constants.Types.ITypedExpression}{BuilderName}<{typeName.GetGenericArguments()}>>",
+                "{0} = source.{0}.Select(x => " + init + ").ToList()",
+                builderCollectionTypeName: BuilderClassCollectionType.WithoutGenerics(),
+                builderName: BuilderName,
+                buildMethodName: BuilderBuildMethodName
+            );
+            property.WithTypeName($"{typeof(IEnumerable<>).WithoutGenerics()}<{Constants.Namespaces.DomainContracts}.{Constants.Types.ITypedExpression}<{typeName.GetGenericArguments()}>>");
 
-                AddEnumerableTypedExpressionPropertyBuilderOverload(property);
-            }
-            else if (typeName == $"{typeof(IReadOnlyCollection<>).WithoutGenerics()}<{Constants.Namespaces.Domain}.{Constants.Types.Expression}>")
-            {
-                AddEnumerableExpressionPropertyBuilderOverload(property);
-            }
-            else if (typeName.GetClassName() == Constants.Types.Expression)
-            {
-                AddSingleExpressionPropertyBuilderOverload(property);
-            }
+            AddEnumerableTypedExpressionPropertyBuilderOverload(property);
+        }
+        else if (typeName == $"{typeof(IReadOnlyCollection<>).WithoutGenerics()}<{Constants.Namespaces.Domain}.{Constants.Types.Expression}>")
+        {
+            AddEnumerableExpressionPropertyBuilderOverload(property);
+        }
+        else if (typeName.GetClassName() == Constants.Types.Expression)
+        {
+            AddSingleExpressionPropertyBuilderOverload(property);
         }
         base.FixImmutableBuilderProperty(property, typeName);
     }
 
-    private static void AddSingleTypedExpressionPropertyBuilderOverload(ClassPropertyBuilder property)
+    private string CreateAssignment(ClassPropertyBuilder property, string typeName)
+    {
+        var init = BuilderName == "Builder"
+            ? $"{Constants.Namespaces.DomainBuilders}.{nameof(Expressions.ExpressionBuilderFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(source.{{0}})"
+            : $"{Constants.Namespaces.DomainModels}.{nameof(Expressions.ExpressionModelFactory)}.CreateTyped<{typeName.GetGenericArguments()}>(source.{{0}})";
+
+        if (UseLazyInitialization)
+        {
+            return property.IsNullable
+                ? "_{1}Delegate = new (() => source.{0} == null ? null : " + init + ")"
+                : "_{1}Delegate = new (() => " + init + ")";
+        }
+
+        return property.IsNullable
+            ? "{0} = source.{0} == null ? null : " + init
+            : "{0} = " + init;
+    }
+
+    private void AddSingleTypedExpressionPropertyBuilderOverload(ClassPropertyBuilder property)
     {
         // Add builder overload that uses T instead of ITypedExpression<T>, and calls the other overload.
         // we need the Value propery of Nullable<T> for value types...
@@ -86,8 +109,8 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
             new OverloadBuilder()
                 .AddParameter(property.Name.ToString().ToPascalCase().GetCsharpFriendlyName(), CreateTypeName(property), property.IsNullable)
                 .WithInitializeExpression(property.IsNullable
-                    ? $"{{2}} = {property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()} == null ? null : new {Constants.TypeNames.Expressions.TypedConstantExpression}Builder<{property.TypeName.ToString().GetGenericArguments()}>().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()}{suffix});"
-                    : $"{{2}} = new {Constants.TypeNames.Expressions.TypedConstantExpression}Builder<{property.TypeName.ToString().GetGenericArguments()}>().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()}{suffix});"
+                    ? $"{{2}} = {property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()} == null ? null : new {Constants.TypeNames.Expressions.TypedConstantExpression}{BuilderName}<{property.TypeName.ToString().GetGenericArguments()}>().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()}{suffix});"
+                    : $"{{2}} = new {Constants.TypeNames.Expressions.TypedConstantExpression}{BuilderName}<{property.TypeName.ToString().GetGenericArguments()}>().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()}{suffix});"
                 ).Build()
             );
 
@@ -96,18 +119,18 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
                 .AddParameter(property.Name.ToString().ToPascalCase().GetCsharpFriendlyName(), $"System.Func<{typeof(object).FullName}?, {CreateTypeName(property)}>", property.IsNullable)
                 .WithInitializeExpression(property.IsNullable
                     ? $"{{2}} = {property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()} == null ? null : new {Constants.TypeNames.Expressions.TypedDelegateExpression}Builder<{property.TypeName.ToString().GetGenericArguments()}>().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
-                    : $"{{2}} = new {Constants.TypeNames.Expressions.TypedDelegateExpression}Builder<{property.TypeName.ToString().GetGenericArguments()}>().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
+                    : $"{{2}} = new {Constants.TypeNames.Expressions.TypedDelegateExpression}{BuilderName}<{property.TypeName.ToString().GetGenericArguments()}>().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
                 ).Build()
             );
     }
 
-    private static void AddEnumerableTypedExpressionPropertyBuilderOverload(ClassPropertyBuilder property)
+    private void AddEnumerableTypedExpressionPropertyBuilderOverload(ClassPropertyBuilder property)
     {
         // Add builder overload for IEnumerable<T> and T[], that maps to value.Select(x => new ConstantTypedExpression<T>().WithValue(x)) and value.Select(x => new ConstantDelegateExpression<T>().WithValue(x))
         property.AddBuilderOverload(
             new OverloadBuilder()
                 .AddParameters(new ParameterBuilder().WithName(property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()).WithTypeName($"{CreateTypeName(property)}[]").WithIsParamArray())
-                .WithInitializeExpression($"Add{{4}}({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()}.Select(x => new {Constants.Namespaces.DomainBuildersExpressions}.{Constants.TypeNames.Expressions.TypedConstantExpression}Builder<{CreateTypeName(property)}>().WithValue(x)));")
+                .WithInitializeExpression($"Add{{4}}({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()}.Select(x => new {Constants.Namespaces.DomainBuildersExpressions}.{Constants.TypeNames.Expressions.TypedConstantExpression}{BuilderName}<{CreateTypeName(property)}>().WithValue(x)));")
                 .Build()
         );
 
@@ -119,35 +142,35 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
         );
     }
 
-    private static void AddSingleExpressionPropertyBuilderOverload(ClassPropertyBuilder property)
+    private void AddSingleExpressionPropertyBuilderOverload(ClassPropertyBuilder property)
     {
         // Add builder overload with type object/object? that maps to new ConstantEvaluatableBuilder().WithValue(value)
         property.AddBuilderOverload(
             new OverloadBuilder()
                 .AddParameter(property.Name.ToString().ToPascalCase().GetCsharpFriendlyName(), typeof(object), property.IsNullable)
                 .WithInitializeExpression(property.IsNullable
-                    ? $"{{2}} = {property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()} == null ? null : new {Constants.TypeNames.Expressions.ConstantExpression}Builder().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
-                    : $"{{2}} = new {Constants.TypeNames.Expressions.ConstantExpression}Builder().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
+                    ? $"{{2}} = {property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()} == null ? null : new {Constants.TypeNames.Expressions.ConstantExpression}{BuilderName}().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
+                    : $"{{2}} = new {Constants.TypeNames.Expressions.ConstantExpression}{BuilderName}().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
                 ).Build()
             );
 
         property.AddBuilderOverload(
             new OverloadBuilder()
-                .AddParameter(property.Name.ToString().ToPascalCase().GetCsharpFriendlyName(), $"System.Func<{typeof(object).FullName}?, {typeof(object).FullName}>", property.IsNullable)
+                .AddParameter(property.Name.ToString().ToPascalCase().GetCsharpFriendlyName(), $"{typeof(Func<>).WithoutGenerics()}<{typeof(object).FullName}?, {typeof(object).FullName}>", property.IsNullable)
                 .WithInitializeExpression(property.IsNullable
-                    ? $"{{2}} = {property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()} == null ? null : new {Constants.TypeNames.Expressions.DelegateExpression}Builder().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
-                    : $"{{2}} = new {Constants.TypeNames.Expressions.DelegateExpression}Builder().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
+                    ? $"{{2}} = {property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()} == null ? null : new {Constants.TypeNames.Expressions.DelegateExpression}{BuilderName}().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
+                    : $"{{2}} = new {Constants.TypeNames.Expressions.DelegateExpression}{BuilderName}().WithValue({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()});"
                 ).Build()
             );
     }
 
-    private static void AddEnumerableExpressionPropertyBuilderOverload(ClassPropertyBuilder property)
+    private void AddEnumerableExpressionPropertyBuilderOverload(ClassPropertyBuilder property)
     {
         // Add builder overload with type IEnumerable that maps to value.OfType<object>().Select(x => new ConstantExpressionBuilder().WithValue(value))
         property.AddBuilderOverload(
             new OverloadBuilder()
                 .AddParameters(new ParameterBuilder().WithName(property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()).WithType(typeof(object[])).WithIsParamArray())
-                .WithInitializeExpression($"Add{{4}}({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()}.Select(x => new {Constants.Namespaces.DomainBuildersExpressions}.{Constants.TypeNames.Expressions.ConstantExpression}Builder().WithValue(x)));")
+                .WithInitializeExpression($"Add{{4}}({property.Name.ToString().ToPascalCase().GetCsharpFriendlyName()}.Select(x => new {Constants.Namespaces.DomainBuildersExpressions}.{Constants.TypeNames.Expressions.ConstantExpression}{BuilderName}().WithValue(x)));")
                 .Build()
         );
 
@@ -266,7 +289,7 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
             : string.Empty;
 
         var genericType = GetCustomType(prop.TypeName.GetGenericArguments());
-        if (prop.TypeName.WithoutProcessedGenerics().GetClassName() == "ITypedExpression" && !string.IsNullOrEmpty(genericType.MethodType))
+        if (prop.TypeName.WithoutProcessedGenerics().GetClassName() == Constants.Types.ITypedExpression && !string.IsNullOrEmpty(genericType.MethodType))
         {
             return $"var {prop.Name.ToPascalCase()}Result = functionParseResult.GetArgument{genericType.MethodType}ValueResult({index}, {prop.Name.CsharpFormat()}, functionParseResult.Context, evaluator, parser{defaultValueSuffix});";
         }
@@ -277,7 +300,7 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
         else if (prop.TypeName.WithoutProcessedGenerics().GetClassName() == typeof(IMultipleTypedExpressions<>).WithoutGenerics().GetClassName())
         {
             // This is an ugly hack to transform IMultipleTypedExpression<T> in the code generation model to IEnumerable<ITypedExpression<T>> in the domain model.
-            return $"var {prop.Name.ToPascalCase()}Result = functionParseResult.GetArgumentExpressionResult<{$"{typeof(IEnumerable<>).WithoutGenerics()}<{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}<{prop.TypeName.GetGenericArguments()}>>"}>({index}, {prop.Name.CsharpFormat()}, functionParseResult.Context, evaluator, parser{defaultValueSuffix});";
+            return $"var {prop.Name.ToPascalCase()}Result = functionParseResult.GetArgumentExpressionResult<{$"{typeof(IEnumerable<>).WithoutGenerics()}<{Constants.Namespaces.DomainContracts}.{Constants.Types.ITypedExpression}<{prop.TypeName.GetGenericArguments()}>>"}>({index}, {prop.Name.CsharpFormat()}, functionParseResult.Context, evaluator, parser{defaultValueSuffix});";
         }
         else
         {
@@ -368,7 +391,7 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
 
     private static string CreateTypeName(ClassPropertyBuilder builder)
     {
-        if (builder.TypeName.ToString().WithoutProcessedGenerics().GetClassName() == typeof(ITypedExpression<>).WithoutGenerics().GetClassName())
+        if (builder.TypeName.ToString().WithoutProcessedGenerics().GetClassName() == Constants.Types.ITypedExpression)
         {
             if (builder.Name.ToString() == Constants.ArgumentNames.PredicateExpression)
             {
@@ -381,7 +404,7 @@ public abstract partial class ExpressionFrameworkCSharpClassBase : CSharpClassBa
             }
         }
 
-        if (builder.TypeName.ToString().GetGenericArguments().StartsWith($"{Constants.Namespaces.DomainContracts}.ITypedExpression"))
+        if (builder.TypeName.ToString().GetGenericArguments().StartsWith($"{Constants.Namespaces.DomainContracts}.{Constants.Types.ITypedExpression}"))
         {
             return builder.TypeName.ToString().GetGenericArguments().GetGenericArguments();
         }

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkModelClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkModelClassBase.cs
@@ -1,5 +1,6 @@
 ﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders;
 
+[ExcludeFromCodeCoverage]
 public abstract class ExpressionFrameworkModelClassBase : ExpressionFrameworkCSharpClassBase
 {
     protected override string AddMethodNameFormatString => string.Empty; // we don't want Add methods for collection properties

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkModelClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkModelClassBase.cs
@@ -1,0 +1,14 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders;
+
+public abstract class ExpressionFrameworkModelClassBase : ExpressionFrameworkCSharpClassBase
+{
+    protected override string AddMethodNameFormatString => string.Empty; // we don't want Add methods for collection properties
+    protected override string SetMethodNameFormatString => string.Empty; // we don't want With methods for non-collection properties
+    protected override string BuilderNameFormatString => "{0}Model";
+    protected override string BuilderBuildMethodName => "ToEntity";
+    protected override string BuilderBuildTypedMethodName => "ToTypedEntity";
+    protected override string BuilderName => "Model";
+    protected override string BuildersName => "Models";
+    protected override bool UseLazyInitialization => false; // we don't want lazy stuff in models, just getters and setters
+    protected override bool PerformBuilderStuff => false;
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkModelClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkModelClassBase.cs
@@ -12,4 +12,5 @@ public abstract class ExpressionFrameworkModelClassBase : ExpressionFrameworkCSh
     protected override string BuilderFactoryName => "ModelFactory";
     protected override bool UseLazyInitialization => false; // we don't want lazy stuff in models, just getters and setters
     protected override bool ConvertStringToStringBuilderOnBuilders => false;
+    protected override Type BuilderClassCollectionType => typeof(List<>);
 }

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkModelClassBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/ExpressionFrameworkModelClassBase.cs
@@ -9,6 +9,7 @@ public abstract class ExpressionFrameworkModelClassBase : ExpressionFrameworkCSh
     protected override string BuilderBuildTypedMethodName => "ToTypedEntity";
     protected override string BuilderName => "Model";
     protected override string BuildersName => "Models";
+    protected override string BuilderFactoryName => "ModelFactory";
     protected override bool UseLazyInitialization => false; // we don't want lazy stuff in models, just getters and setters
-    protected override bool PerformBuilderStuff => false;
+    protected override bool ConvertStringToStringBuilderOnBuilders => false;
 }

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Expressions/ExpressionModelFactory.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Expressions/ExpressionModelFactory.cs
@@ -1,0 +1,21 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.Expressions;
+
+[ExcludeFromCodeCoverage]
+public class ExpressionModelFactory : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Namespaces.DomainModels;
+
+    public override object CreateModel()
+        => CreateBuilderFactoryModels(
+            GetOverrideModels(typeof(IExpression)),
+            new(
+                Constants.Namespaces.DomainModels,
+                nameof(ExpressionModelFactory),
+                Constants.TypeNames.Expression,
+                Constants.Namespaces.DomainModelsExpressions,
+                Constants.Types.ExpressionModel,
+                Constants.Namespaces.DomainExpressions
+            ),
+            $"if (instance is {Constants.Namespaces.DomainContracts}.{nameof(IUntypedExpressionProvider)} provider) instance = provider.ToUntyped();"
+        );
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Expressions/OverrideModels.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Expressions/OverrideModels.cs
@@ -1,0 +1,18 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.Expressions;
+
+[ExcludeFromCodeCoverage]
+public class OverrideModels : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Paths.ExpressionModels;
+
+    protected override bool EnableEntityInheritance => true;
+    protected override bool EnableBuilderInhericance => true;
+    protected override IClass? BaseClass => CreateBaseclass(typeof(IExpression), Constants.Namespaces.Domain);
+    protected override string BaseClassBuilderNamespace => Constants.Namespaces.DomainModels;
+
+    public override object CreateModel()
+        => GetImmutableBuilderClasses(
+            GetOverrideModels(typeof(IExpression)),
+            Constants.Namespaces.DomainExpressions,
+            CurrentNamespace);
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Operators/OperatorModelFactory.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Operators/OperatorModelFactory.cs
@@ -1,0 +1,20 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.Operators;
+
+[ExcludeFromCodeCoverage]
+public class OperatorModelFactory : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Namespaces.DomainModels;
+
+    public override object CreateModel()
+        => CreateBuilderFactoryModels(
+            GetOverrideModels(typeof(IOperator)),
+            new(
+                Constants.Namespaces.DomainModels,
+                nameof(OperatorModelFactory),
+                Constants.TypeNames.Operator,
+                Constants.Namespaces.DomainModelsOperators,
+                Constants.Types.OperatorModel,
+                Constants.Namespaces.DomainOperators
+            )
+        );
+}

--- a/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Operators/OverrideModels.cs
+++ b/src/ExpressionFramework.CodeGeneration/CodeGenerationProviders/Operators/OverrideModels.cs
@@ -1,0 +1,19 @@
+﻿namespace ExpressionFramework.CodeGeneration.CodeGenerationProviders.Operators;
+
+[ExcludeFromCodeCoverage]
+public class OverrideModels : ExpressionFrameworkModelClassBase
+{
+    public override string Path => Constants.Paths.OperatorModels;
+
+    protected override bool EnableEntityInheritance => true;
+    protected override bool EnableBuilderInhericance => true;
+    protected override IClass? BaseClass => CreateBaseclass(typeof(IOperator), Constants.Namespaces.Domain);
+    protected override string BaseClassBuilderNamespace => Constants.Namespaces.DomainModels;
+    protected override ArgumentValidationType ValidateArgumentsInConstructor => ArgumentValidationType.None; // there are no properties in operators, so this is not necessary
+
+    public override object CreateModel()
+        => GetImmutableBuilderClasses(
+            GetOverrideModels(typeof(IOperator)),
+            Constants.Namespaces.DomainOperators,
+            CurrentNamespace);
+}

--- a/src/ExpressionFramework.CodeGeneration/Constants.cs
+++ b/src/ExpressionFramework.CodeGeneration/Constants.cs
@@ -10,6 +10,7 @@ public static class Constants
         public const string Domain = "ExpressionFramework.Domain";
         public const string DomainContracts = "ExpressionFramework.Domain.Contracts";
         public const string DomainBuilders = "ExpressionFramework.Domain.Builders";
+        public const string DomainModels = "ExpressionFramework.Domain.Models";
         public const string DomainSpecialized = "ExpressionFramework.Domain.Specialized";
         public const string Parser = "ExpressionFramework.Parser";
 

--- a/src/ExpressionFramework.CodeGeneration/Constants.cs
+++ b/src/ExpressionFramework.CodeGeneration/Constants.cs
@@ -24,6 +24,11 @@ public static class Constants
         public const string DomainBuildersExpressions = "ExpressionFramework.Domain.Builders.Expressions";
         public const string DomainBuildersOperators = "ExpressionFramework.Domain.Builders.Operators";
 
+        public const string DomainModelsAggregators = "ExpressionFramework.Domain.Models.Aggregators";
+        public const string DomainModelsEvaluatables = "ExpressionFramework.Domain.Models.Evaluatables";
+        public const string DomainModelsExpressions = "ExpressionFramework.Domain.Models.Expressions";
+        public const string DomainModelsOperators = "ExpressionFramework.Domain.Models.Operators";
+
         public const string DomainAggregators = "ExpressionFramework.Domain.Aggregators";
         public const string DomainEvaluatables = "ExpressionFramework.Domain.Evaluatables";
         public const string DomainExpressions = "ExpressionFramework.Domain.Expressions";
@@ -42,6 +47,11 @@ public static class Constants
         public const string EvaluatableBuilder = "EvaluatableBuilder";
         public const string ExpressionBuilder = "ExpressionBuilder";
         public const string OperatorBuilder = "OperatorBuilder";
+
+        public const string AggregatorModel = "AggregatorModel";
+        public const string EvaluatableModel = "EvaluatableModel";
+        public const string ExpressionModel = "ExpressionModel";
+        public const string OperatorModel = "OperatorModel";
     }
 
     [ExcludeFromCodeCoverage]
@@ -73,6 +83,11 @@ public static class Constants
         public const string EvaluatableBuilders = $"{Namespaces.DomainBuilders}/{nameof(Evaluatables)}";
         public const string ExpressionBuilders = $"{Namespaces.DomainBuilders}/{nameof(Expressions)}";
         public const string OperatorBuilders = $"{Namespaces.DomainBuilders}/{nameof(Operators)}";
+
+        public const string AggregatorModels = $"{Namespaces.DomainModels}/{nameof(Aggregators)}";
+        public const string EvaluatableModels = $"{Namespaces.DomainModels}/{nameof(Evaluatables)}";
+        public const string ExpressionModels = $"{Namespaces.DomainModels}/{nameof(Expressions)}";
+        public const string OperatorModels = $"{Namespaces.DomainModels}/{nameof(Operators)}";
 
         public const string ParserAggregatorResultParsers = $"{Namespaces.Parser}/AggregatorResultParsers";
         public const string ParserEvaluatableResultParsers = $"{Namespaces.Parser}/EvaluatableResultParsers";

--- a/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
+++ b/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="pauldeen79.CrossCutting.DataTableDumper" Version="2.7.53" />
     <PackageReference Include="pauldeen79.CrossCutting.Utilities.Parsers" Version="2.7.53" />
-    <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.71" />
+    <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.72" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
+++ b/src/ExpressionFramework.CodeGeneration/ExpressionFramework.CodeGeneration.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="pauldeen79.CrossCutting.DataTableDumper" Version="2.7.53" />
     <PackageReference Include="pauldeen79.CrossCutting.Utilities.Parsers" Version="2.7.53" />
-    <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.72" />
+    <PackageReference Include="pauldeen79.ModelFramework.CodeGeneration" Version="0.6.73" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/ExpressionFramework.CodeGeneration/Program.cs
+++ b/src/ExpressionFramework.CodeGeneration/Program.cs
@@ -20,8 +20,11 @@ internal static class Program
         var settings = new CodeGenerationSettings(basePath, generateMultipleFiles, dryRun);
 
         // Generate code
-        var expressionFrameworkGenerators = typeof(ExpressionFrameworkCSharpClassBase).Assembly.GetExportedTypes().Where(x => x.BaseType == typeof(ExpressionFrameworkCSharpClassBase) && !x.IsAbstract).ToArray();
+        var expressionFrameworkGenerators = typeof(ExpressionFrameworkCSharpClassBase).Assembly.GetExportedTypes().Where(x => !x.IsAbstract && x.BaseType == typeof(ExpressionFrameworkCSharpClassBase) && !x.IsAbstract).ToArray();
         _ = expressionFrameworkGenerators.Select(x => (ExpressionFrameworkCSharpClassBase)Activator.CreateInstance(x)!).Select(x => GenerateCode.For(x.GetSettings(settings), multipleContentBuilder, x)).ToArray();
+
+        var modelGenerators = typeof(ExpressionFrameworkModelClassBase).Assembly.GetExportedTypes().Where(x => !x.IsAbstract && x.BaseType == typeof(ExpressionFrameworkModelClassBase)).ToArray();
+        _ = modelGenerators.Select(x => (ExpressionFrameworkModelClassBase)Activator.CreateInstance(x)!).Select(x => GenerateCode.For(x.GetSettings(settings), multipleContentBuilder, x)).ToArray();
 
         // Log output to console
         if (string.IsNullOrEmpty(basePath))

--- a/src/ExpressionFramework.CodeGeneration/Visitors/BuilderVisitorBase.cs
+++ b/src/ExpressionFramework.CodeGeneration/Visitors/BuilderVisitorBase.cs
@@ -1,0 +1,30 @@
+﻿namespace ExpressionFramework.CodeGeneration.Visitors;
+
+[ExcludeFromCodeCoverage]
+public static class BuilderVisitorBase
+{
+    public static void Visit<TBuilder, TEntity>(TypeBaseBuilder<TBuilder, TEntity> typeBaseBuilder, VisitorContext context, string ns, string typedMethodName, string untypedMethodName, string builderName)
+    where TBuilder : TypeBaseBuilder<TBuilder, TEntity>
+    where TEntity : ITypeBase
+    {
+        if (typeBaseBuilder.Namespace.ToString() != ns)
+        {
+            return;
+        }
+
+        var buildTypedMethod = typeBaseBuilder.Methods.First(x => x.Name.ToString() == typedMethodName);
+        if (!context.TypedInterfaceMap.TryGetValue(buildTypedMethod.TypeName.ToString().WithoutProcessedGenerics(), out var typedInterface))
+        {
+            return;
+        }
+
+        typeBaseBuilder.AddMethods
+        (
+            new ClassMethodBuilder()
+                .WithName(untypedMethodName)
+                .WithTypeName($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}<{typedInterface.GetGenericArguments()}>")
+                .AddLiteralCodeStatements($"return {typedMethodName}();")
+                .WithExplicitInterfaceName($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}{builderName}<{typedInterface.GetGenericArguments()}>")
+        ).AddInterfaces($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}{builderName}<{typedInterface.GetGenericArguments()}>");
+    }
+}

--- a/src/ExpressionFramework.CodeGeneration/Visitors/TypedExpressionBuilderVisitor.cs
+++ b/src/ExpressionFramework.CodeGeneration/Visitors/TypedExpressionBuilderVisitor.cs
@@ -3,30 +3,17 @@
 [ExcludeFromCodeCoverage]
 public class TypedExpressionBuilderVisitor : IVisitor
 {
-    public int Order => 30;
+    public int Order => 31;
 
     public void Visit<TBuilder, TEntity>(TypeBaseBuilder<TBuilder, TEntity> typeBaseBuilder, VisitorContext context)
         where TBuilder : TypeBaseBuilder<TBuilder, TEntity>
-        where TEntity : ITypeBase
-    {
-        if (typeBaseBuilder.Namespace.ToString() != Constants.Namespaces.DomainBuildersExpressions)
-        {
-            return;
-        }
-
-        var buildTypedMethod = typeBaseBuilder.Methods.First(x => x.Name.ToString() == "BuildTyped");
-        if (!context.TypedInterfaceMap.TryGetValue(buildTypedMethod.TypeName.ToString().WithoutProcessedGenerics(), out var typedInterface))
-        {
-            return;
-        }
-
-        typeBaseBuilder.AddMethods
+        where TEntity : ITypeBase => BuilderVisitorBase.Visit
         (
-            new ClassMethodBuilder()
-                .WithName("Build")
-                .WithTypeName($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}<{typedInterface.GetGenericArguments()}>")
-                .AddLiteralCodeStatements("return BuildTyped();")
-                .WithExplicitInterfaceName($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}Builder<{typedInterface.GetGenericArguments()}>")
-        ).AddInterfaces($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}Builder<{typedInterface.GetGenericArguments()}>");
-    }
+            typeBaseBuilder,
+            context,
+            Constants.Namespaces.DomainBuildersExpressions,
+            "BuildTyped",
+            "Build",
+            "Builder"
+        );
 }

--- a/src/ExpressionFramework.CodeGeneration/Visitors/TypedExpressionModelVisitor.cs
+++ b/src/ExpressionFramework.CodeGeneration/Visitors/TypedExpressionModelVisitor.cs
@@ -3,30 +3,17 @@
 [ExcludeFromCodeCoverage]
 public class TypedExpressionModelVisitor : IVisitor
 {
-    public int Order => 30;
+    public int Order => 32;
 
     public void Visit<TBuilder, TEntity>(TypeBaseBuilder<TBuilder, TEntity> typeBaseBuilder, VisitorContext context)
         where TBuilder : TypeBaseBuilder<TBuilder, TEntity>
-        where TEntity : ITypeBase
-    {
-        if (typeBaseBuilder.Namespace.ToString() != Constants.Namespaces.DomainModelsExpressions)
-        {
-            return;
-        }
-
-        var buildTypedMethod = typeBaseBuilder.Methods.First(x => x.Name.ToString() == "ToTypedEntity");
-        if (!context.TypedInterfaceMap.TryGetValue(buildTypedMethod.TypeName.ToString().WithoutProcessedGenerics(), out var typedInterface))
-        {
-            return;
-        }
-
-        typeBaseBuilder.AddMethods
+        where TEntity : ITypeBase => BuilderVisitorBase.Visit
         (
-            new ClassMethodBuilder()
-                .WithName("ToEntity")
-                .WithTypeName($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}<{typedInterface.GetGenericArguments()}>")
-                .AddLiteralCodeStatements("return ToTypedEntity();")
-                .WithExplicitInterfaceName($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}Model<{typedInterface.GetGenericArguments()}>")
-        ).AddInterfaces($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}Model<{typedInterface.GetGenericArguments()}>");
-    }
+            typeBaseBuilder,
+            context,
+            Constants.Namespaces.DomainModelsExpressions,
+            "ToTypedEntity",
+            "ToEntity",
+            "Model"
+        );
 }

--- a/src/ExpressionFramework.CodeGeneration/Visitors/TypedExpressionModelVisitor.cs
+++ b/src/ExpressionFramework.CodeGeneration/Visitors/TypedExpressionModelVisitor.cs
@@ -1,0 +1,32 @@
+﻿namespace ExpressionFramework.CodeGeneration.Visitors;
+
+[ExcludeFromCodeCoverage]
+public class TypedExpressionModelVisitor : IVisitor
+{
+    public int Order => 30;
+
+    public void Visit<TBuilder, TEntity>(TypeBaseBuilder<TBuilder, TEntity> typeBaseBuilder, VisitorContext context)
+        where TBuilder : TypeBaseBuilder<TBuilder, TEntity>
+        where TEntity : ITypeBase
+    {
+        if (typeBaseBuilder.Namespace.ToString() != Constants.Namespaces.DomainModelsExpressions)
+        {
+            return;
+        }
+
+        var buildTypedMethod = typeBaseBuilder.Methods.First(x => x.Name.ToString() == "ToTypedEntity");
+        if (!context.TypedInterfaceMap.TryGetValue(buildTypedMethod.TypeName.ToString().WithoutProcessedGenerics(), out var typedInterface))
+        {
+            return;
+        }
+
+        typeBaseBuilder.AddMethods
+        (
+            new ClassMethodBuilder()
+                .WithName("ToEntity")
+                .WithTypeName($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}<{typedInterface.GetGenericArguments()}>")
+                .AddLiteralCodeStatements("return ToTypedEntity();")
+                .WithExplicitInterfaceName($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}Model<{typedInterface.GetGenericArguments()}>")
+        ).AddInterfaces($"{Constants.Namespaces.DomainContracts}.{typeof(ITypedExpression<>).WithoutGenerics().GetClassName()}Model<{typedInterface.GetGenericArguments()}>");
+    }
+}

--- a/src/ExpressionFramework.Domain.Models/ExpressionFramework.Domain.Models.csproj
+++ b/src/ExpressionFramework.Domain.Models/ExpressionFramework.Domain.Models.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>11.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <PackageId>pauldeen79.ExpressionFramework.Domain.Models</PackageId>
+    <RepositoryUrl>https://github.com/pauldeen79/ExpressionFramework</RepositoryUrl>
+    <CodeAnalysisRuleSet>..\..\.sonarlint\pauldeen79_expressionframeworkcsharp.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\.sonarlint\pauldeen79_expressionframework\CSharp\SonarLint.xml" Link="SonarLint.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ExpressionFramework.Domain\ExpressionFramework.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ExpressionFramework.Domain.Models/ExpressionFramework.Domain.Models.csproj
+++ b/src/ExpressionFramework.Domain.Models/ExpressionFramework.Domain.Models.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ExpressionFramework.Domain\ExpressionFramework.Domain.csproj" />
+    <ProjectReference Include="..\ExpressionFramework.Domain.Specialized\ExpressionFramework.Domain.Specialized.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ExpressionFramework.Domain.Models/ExpressionModelFactory.cs
+++ b/src/ExpressionFramework.Domain.Models/ExpressionModelFactory.cs
@@ -1,0 +1,22 @@
+﻿namespace ExpressionFramework.Domain.Models;
+
+public static partial class ExpressionModelFactory
+{
+    public static ITypedExpressionModel<T> CreateTyped<T>(ITypedExpression<T> source)
+        => source switch
+        {
+            TypedConstantExpression<T> x => new TypedConstantExpressionModel<T>(x),
+            TypedConstantResultExpression<T> x => new TypedConstantResultExpressionModel<T>(x),
+            TypedDelegateExpression<T> x => new TypedDelegateExpressionModel<T>(x),
+            TypedDelegateResultExpression<T> x => new TypedDelegateResultExpressionModel<T>(x),
+            _ => CreateStandard(source)
+        };
+
+    private static ITypedExpressionModel<T> CreateStandard<T>(ITypedExpression<T> source)
+    {
+        var registration = registeredTypes.Select(kvp => new { kvp.Key, kvp.Value }).FirstOrDefault(keyValuePair => typeof(ITypedExpression<T>).IsAssignableFrom(keyValuePair.Key) && source.GetType().IsAssignableFrom(keyValuePair.Key));
+        return registration == null
+            ? throw new NotSupportedException($"Expression of type [{source.GetType()}] is not supported")
+            : (ITypedExpressionModel<T>)registration.Value.Invoke((Expression)source);
+    }
+}

--- a/src/ExpressionFramework.Domain.Models/GlobalUsings.cs
+++ b/src/ExpressionFramework.Domain.Models/GlobalUsings.cs
@@ -1,0 +1,5 @@
+﻿global using System;
+global using System.Linq;
+global using ExpressionFramework.Domain.Contracts;
+global using ExpressionFramework.Domain.Expressions;
+global using ExpressionFramework.Domain.Models.Expressions;

--- a/src/ExpressionFramework.Domain.Tests/ExpressionFramework.Domain.Tests.csproj
+++ b/src/ExpressionFramework.Domain.Tests/ExpressionFramework.Domain.Tests.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ExpressionFramework.Domain.Builders\ExpressionFramework.Domain.Builders.csproj" />
+    <ProjectReference Include="..\ExpressionFramework.Domain.Models\ExpressionFramework.Domain.Models.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ExpressionFramework.Domain.Tests/ImplicitUsings.cs
+++ b/src/ExpressionFramework.Domain.Tests/ImplicitUsings.cs
@@ -18,6 +18,8 @@ global using ExpressionFramework.Domain.EvaluatableDescriptorProviders;
 global using ExpressionFramework.Domain.Evaluatables;
 global using ExpressionFramework.Domain.ExpressionDescriptorProviders;
 global using ExpressionFramework.Domain.Expressions;
+global using ExpressionFramework.Domain.Models;
+global using ExpressionFramework.Domain.Models.Expressions;
 global using ExpressionFramework.Domain.OperatorDescriptorProviders;
 global using ExpressionFramework.Domain.Operators;
 global using ExpressionFramework.SpecFlow.Tests.Support;

--- a/src/ExpressionFramework.Domain.Tests/Unit/Builders/ExpressionBuilderFactoryTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Builders/ExpressionBuilderFactoryTests.cs
@@ -56,29 +56,7 @@ public class ExpressionBuilderFactoryTests
     public void CreateTyped_Throws_On_Unsupported_Expression()
     {
         // Act & Assert
-        this.Invoking(_ => ExpressionBuilderFactory.CreateTyped(new MyUnsupportedExpression())).Should().Throw<NotSupportedException>();
-    }
-
-    private sealed record MyUnsupportedExpression : Expression, ITypedExpression<int>
-    {
-        public override Result<object?> Evaluate(object? context)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Result<int> EvaluateTyped(object? context)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override Result<Expression> GetSingleContainedExpression()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Expression ToUntyped()
-        {
-            throw new NotImplementedException();
-        }
+        this.Invoking(_ => ExpressionBuilderFactory.CreateTyped(new Mock<ITypedExpression<string>>().Object))
+            .Should().Throw<NotSupportedException>();
     }
 }

--- a/src/ExpressionFramework.Domain.Tests/Unit/Models/ExpressionModelFactoryTests.cs
+++ b/src/ExpressionFramework.Domain.Tests/Unit/Models/ExpressionModelFactoryTests.cs
@@ -1,0 +1,62 @@
+﻿namespace ExpressionFramework.Domain.Tests.Unit.Models;
+
+public class ExpressionModelFactoryTests
+{
+    [Fact]
+    public void CreateTyped_Returns_Correct_Result_On_TypedConstantExpression()
+    {
+        // Act
+        var result = ExpressionModelFactory.CreateTyped(new TypedConstantExpression<int>(1));
+
+        // Assert
+        result.Should().BeOfType<TypedConstantExpressionModel<int>>();
+    }
+
+    [Fact]
+    public void CreateTyped_Returns_Correct_Result_On_TypedConstantResultExpression()
+    {
+        // Act
+        var result = ExpressionModelFactory.CreateTyped(new TypedConstantResultExpression<int>(Result<int>.Success(1)));
+
+        // Assert
+        result.Should().BeOfType<TypedConstantResultExpressionModel<int>>();
+    }
+
+    [Fact]
+    public void CreateTyped_Returns_Correct_Result_On_TypedDelegateExpression()
+    {
+        // Act
+        var result = ExpressionModelFactory.CreateTyped(new TypedDelegateExpression<int>(_ => 1));
+
+        // Assert
+        result.Should().BeOfType<TypedDelegateExpressionModel<int>>();
+    }
+
+    [Fact]
+    public void CreateTyped_Returns_Correct_Result_On_TypedDelegateResultExpression()
+    {
+        // Act
+        var result = ExpressionModelFactory.CreateTyped(new TypedDelegateResultExpression<int>(_ => Result<int>.Success(1)));
+
+        // Assert
+        result.Should().BeOfType<TypedDelegateResultExpressionModel<int>>();
+    }
+
+    [Fact]
+    public void CreateTyped_Returns_Correct_Result_On_Default_Generated_Expression()
+    {
+        // Act
+        var result = ExpressionModelFactory.CreateTyped(new StringLengthExpressionBuilder().WithExpression("test").BuildTyped());
+
+        // Assert
+        result.Should().BeOfType<StringLengthExpressionModel>();
+    }
+
+    [Fact]
+    public void CreateTyped_Throws_On_Unsupported_Expression()
+    {
+        // Act & Assert
+        this.Invoking(_ => ExpressionModelFactory.CreateTyped(new Mock<ITypedExpression<string>>().Object))
+            .Should().Throw<NotSupportedException>();
+    }
+}

--- a/src/ExpressionFramework.Domain/Contracts/ITypedExpressionModel.cs
+++ b/src/ExpressionFramework.Domain/Contracts/ITypedExpressionModel.cs
@@ -1,0 +1,6 @@
+﻿namespace ExpressionFramework.Domain.Contracts;
+
+public interface ITypedExpressionModel<T>
+{
+    ITypedExpression<T> ToEntity();
+}


### PR DESCRIPTION
Added new package that contains models for all expressions. These are almost the same as builders, but a little simpler:
- No lazy properties, just plain getters and setters on properties
- No StringBuilders on strings, just strings on string properties

I have added support for creating models from existing entities as well. This could also be removed, but it 's easy to generate.