### PR TITLE
Upgrade CrossCutting.Utilities.Parsers to latest version

### DIFF
--- a/src/ExpressionFramework.Domain.Tests/ExpressionFramework.Domain.Tests.csproj
+++ b/src/ExpressionFramework.Domain.Tests/ExpressionFramework.Domain.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ExpressionFramework.Parser.Tests/AggregatorResultParsers/AgregatorParserBaseTests.cs
+++ b/src/ExpressionFramework.Parser.Tests/AggregatorResultParsers/AgregatorParserBaseTests.cs
@@ -8,7 +8,7 @@ public class AggregatorParserBaseTests
     public AggregatorParserBaseTests()
     {
         _functionEvaluatorMock
-            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IExpressionEvaluator>(), Arg.Any<object?>())
+            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<object?>())
             .Returns(Result.Success<object?>(Substitute.For<Aggregator>()));
     }
 

--- a/src/ExpressionFramework.Parser.Tests/EvaluatableResultParsers/EvaluatableParserBaseTests.cs
+++ b/src/ExpressionFramework.Parser.Tests/EvaluatableResultParsers/EvaluatableParserBaseTests.cs
@@ -8,7 +8,7 @@ public class EvaluatableParserBaseTests
     public EvaluatableParserBaseTests()
     {
         _functionEvaluatorMock
-            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IExpressionEvaluator>(), Arg.Any<object?>())
+            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<object?>())
             .Returns(Result.Success<object?>(Substitute.For<Evaluatable>()));
     }
 

--- a/src/ExpressionFramework.Parser.Tests/ExpressionFramework.Parser.Tests.csproj
+++ b/src/ExpressionFramework.Parser.Tests/ExpressionFramework.Parser.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ExpressionFramework.Parser.Tests/ExpressionResultParsers/ExpressionParserBaseTests.cs
+++ b/src/ExpressionFramework.Parser.Tests/ExpressionResultParsers/ExpressionParserBaseTests.cs
@@ -9,7 +9,7 @@ public class ExpressionParserBaseTests
     public ExpressionParserBaseTests()
     {
         _functionEvaluatorMock
-            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IExpressionEvaluator>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>())
+            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>())
             .Returns(Result.Success<object?>(_expressionMock));
         _expressionEvaluatorMock
             .Evaluate(Arg.Any<string>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>())
@@ -83,7 +83,7 @@ public class ExpressionParserBaseTests
     {
         // Arrange
         _functionEvaluatorMock
-            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IExpressionEvaluator>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>())
+            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>())
             .Returns(Result.Success<object?>(null));
         var context = new FunctionCallContext(new FunctionCallBuilder()
             .WithName("Correct")
@@ -102,7 +102,7 @@ public class ExpressionParserBaseTests
     {
         // Arrange
         _functionEvaluatorMock
-            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IExpressionEvaluator>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>())
+            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>())
             .Returns(Result.Error<object?>("Kaboom"));
         var context = new FunctionCallContext(new FunctionCallBuilder()
             .WithName("Correct")

--- a/src/ExpressionFramework.Parser.Tests/IntegrationTests.cs
+++ b/src/ExpressionFramework.Parser.Tests/IntegrationTests.cs
@@ -17,7 +17,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_With_Expression()
+    public void Can_Evaluate_Function_With_Expression()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -31,7 +31,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_With_Expression_And_Using_FormattableStrings_As_Well()
+    public void Can_Evaluate_Function_With_Expression_And_Using_FormattableStrings_As_Well()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -45,7 +45,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_With_Nested_Expression()
+    public void Can_Evaluate_Function_With_Nested_Expression()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -59,7 +59,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_Without_Nested_Expression()
+    public void Can_Evaluate_Function_Without_Nested_Expression()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -73,7 +73,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_With_Context()
+    public void Can_Evaluate_Function_With_Context()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -87,7 +87,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_With_Context_And_Operator()
+    public void Can_Evaluate_Function_With_Context_And_Operator()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -101,7 +101,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_With_Generated_DefaultValue_On_Nullable_Property()
+    public void Can_Evaluate_Function_With_Generated_DefaultValue_On_Nullable_Property()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -115,7 +115,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_With_Supplied_DefaultValue_On_Nullable_Property()
+    public void Can_Evaluate_Function_With_Supplied_DefaultValue_On_Nullable_Property()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -129,7 +129,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Can_Parse_Function_With_Correct_Typed_Arguments()
+    public void Can_Evaluate_Function_With_Correct_Typed_Arguments()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -143,7 +143,7 @@ public sealed class IntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Function_With_String_Argument_Preserves_WhiteSpace()
+    public void Function_With_String_Argument_Preserves_Whitespace()
     {
         // Arrange
         var parser = _scope.ServiceProvider.GetRequiredService<IExpressionStringEvaluator>();
@@ -183,8 +183,5 @@ public sealed class IntegrationTests : IDisposable
         {
             return Result.Success<object?>(context.GetArgumentValueResult(0, "Expression", null).GetValue() is int i && i > 2);
         }
-
-        public Result Validate(FunctionCallContext context)
-            => Result.Success();
     }
 }

--- a/src/ExpressionFramework.Parser.Tests/OperatorResultParsers/OperatorParserBaseTests.cs
+++ b/src/ExpressionFramework.Parser.Tests/OperatorResultParsers/OperatorParserBaseTests.cs
@@ -8,7 +8,7 @@ public class OperatorParserBaseTests
     public OperatorParserBaseTests()
     {
         _functionEvaluatorMock
-            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<IExpressionEvaluator>(), Arg.Any<object?>())
+            .Evaluate(Arg.Any<FunctionCall>(), Arg.Any<object?>())
             .Returns(Result.Success<object?>(Substitute.For<Operator>()));
     }
 

--- a/src/ExpressionFramework.Parser/AggregatorResultParsers/AggregatorParserBase.cs
+++ b/src/ExpressionFramework.Parser/AggregatorResultParsers/AggregatorParserBase.cs
@@ -9,8 +9,5 @@ public abstract class AggregatorParserBase : IFunction
         return Result.FromExistingResult<object?>(DoParse(context));
     }
 
-    public Result Validate(FunctionCallContext context)
-        => Result.Success();
-
     protected abstract Result<Aggregator> DoParse(FunctionCallContext context);
 }

--- a/src/ExpressionFramework.Parser/EvaluatableResultParsers/EvaluatableParserBase.cs
+++ b/src/ExpressionFramework.Parser/EvaluatableResultParsers/EvaluatableParserBase.cs
@@ -9,8 +9,5 @@ public abstract class EvaluatableParserBase : IFunction
         return Result.FromExistingResult<object?>(DoParse(context));
     }
 
-    public Result Validate(FunctionCallContext context)
-        => Result.Success();
-
     protected abstract Result<Evaluatable> DoParse(FunctionCallContext context);
 }

--- a/src/ExpressionFramework.Parser/ExpressionFramework.Parser.csproj
+++ b/src/ExpressionFramework.Parser/ExpressionFramework.Parser.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
-    <PackageReference Include="pauldeen79.CrossCutting.Utilities.Parsers" Version="8.0.0" />
+    <PackageReference Include="pauldeen79.CrossCutting.Utilities.Parsers" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExpressionFramework.Parser/ExpressionFramework.Parser.csproj
+++ b/src/ExpressionFramework.Parser/ExpressionFramework.Parser.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
-    <PackageReference Include="pauldeen79.CrossCutting.Utilities.Parsers" Version="7.1.0" />
+    <PackageReference Include="pauldeen79.CrossCutting.Utilities.Parsers" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExpressionFramework.Parser/ExpressionResultParsers/ExpressionParserBase.cs
+++ b/src/ExpressionFramework.Parser/ExpressionResultParsers/ExpressionParserBase.cs
@@ -20,9 +20,6 @@ public abstract class ExpressionParserBase : IFunction, IExpressionResolver
             : Result.FromExistingResult<object?>(result);
     }
 
-    public Result Validate(FunctionCallContext context)
-        => Result.Success();
-
     public Result<Expression> ParseExpression(FunctionCallContext context)
     {
         context = ArgumentGuard.IsNotNull(context, nameof(context));

--- a/src/ExpressionFramework.Parser/OperatorResultParsers/OperatorParserBase.cs
+++ b/src/ExpressionFramework.Parser/OperatorResultParsers/OperatorParserBase.cs
@@ -9,8 +9,5 @@ public abstract class OperatorParserBase : IFunction
         return Result.FromExistingResult<object?>(DoParse(context));
     }
 
-    public Result Validate(FunctionCallContext context)
-        => Result.Success();
-
     protected abstract Result<Operator> DoParse(FunctionCallContext context);
 }


### PR DESCRIPTION
Still not using the most efficient way, we can just use IFunction and ITypedFunction<T>, and skip Expression and ITypedExpression<T> entirely. This will be done in a future version.